### PR TITLE
Resolve 60 fps lock issue for WGC capture by setting the MinUpdateInterval property of the WGC capture session.

### DIFF
--- a/src/platform/windows/display_wgc.cpp
+++ b/src/platform/windows/display_wgc.cpp
@@ -139,7 +139,7 @@ namespace platf::dxgi {
     }
     try {
       if (winrt::ApiInformation::IsPropertyPresent(L"Windows.Graphics.Capture.GraphicsCaptureSession", L"MinUpdateInterval")) {
-        capture_session.MinUpdateInterval(winrt::TimeSpan{ 10000 });
+        capture_session.MinUpdateInterval(winrt::TimeSpan{ 10000000 / (config.framerate * 2) });
       }
       else {
         BOOST_LOG(warning) << "Can't set MinUpdateInterval";


### PR DESCRIPTION
Resolve 60 fps lock issue for WGC capture by setting the MinUpdateInterval property of the WGC capture session.

Fixes: #676 and partially #620