### PR TITLE
Feature: Added option to disable rumble on controllers from the Apollo side

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -572,6 +572,7 @@ namespace config {
     true,  // high resolution scrolling
     true,  // native pen/touch support
     false, // enable input only mode
+    false, // enable_block_rumble_messages_to_controllers
   };
 
   sunshine_t sunshine {
@@ -1288,6 +1289,7 @@ namespace config {
     bool_f(vars, "envvar_compatibility_mode", sunshine.envvar_compatibility_mode);
     bool_f(vars, "notify_pre_releases", sunshine.notify_pre_releases);
     bool_f(vars, "legacy_ordering", sunshine.legacy_ordering);
+    bool_f(vars, "enable_block_rumble_messages_to_controllers", input.enable_block_rumble_messages_to_controllers);
 
     int port = sunshine.port;
     int_between_f(vars, "port"s, port, {1024 + nvhttp::PORT_HTTPS, 65535 - rtsp_stream::RTSP_SETUP_PORT});

--- a/src/config.h
+++ b/src/config.h
@@ -212,6 +212,7 @@ namespace config {
     bool native_pen_touch;
 
     bool enable_input_only_mode;
+    bool enable_block_rumble_messages_to_controllers;
   };
 
   namespace flag {

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -327,6 +327,11 @@ namespace platf {
      * @param smallMotor The small motor.
      */
     void rumble(target_t::pointer target, std::uint8_t largeMotor, std::uint8_t smallMotor) {
+      // config::input.enable_block_rumble_messages_to_controllers - Default is false so ignore rumble messages when true
+      if( config::input.enable_block_rumble_messages_to_controllers == true ) {
+        // Do nothing; just return
+        return;
+      }
       for (int x = 0; x < gamepads.size(); ++x) {
         auto &gamepad = gamepads[x];
 

--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -3,6 +3,7 @@
  * @brief Definitions for UPnP port mapping.
  */
 // lib includes
+#include <cstddef>   // Needed to compile size_t in Windows
 #include <miniupnpc/miniupnpc.h>
 #include <miniupnpc/upnpcommands.h>
 

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -176,6 +176,7 @@
               "high_resolution_scrolling": "enabled",
               "native_pen_touch": "enabled",
               "enable_input_only_mode": "disabled",
+              "enable_block_rumble_messages_to_controllers": "disabled",
               "keybindings": "[0x10,0xA0,0x11,0xA2,0x12,0xA4]",  // todo: add this to UI
             },
           },

--- a/src_assets/common/assets/web/configs/tabs/Inputs.vue
+++ b/src_assets/common/assets/web/configs/tabs/Inputs.vue
@@ -177,6 +177,17 @@ const config = ref(props.config)
               v-model="config.enable_input_only_mode"
               default="false"
     ></Checkbox>
+
+    <!-- Enable Block Rumble Messages to Controllers -->
+    <hr>
+    <Checkbox v-if="platform === 'windows'"
+              class="mb-3"
+              id="enable_block_rumble_messages_to_controllers"
+              locale-prefix="config"
+              v-model="config.enable_block_rumble_messages_to_controllers"
+              default="false"
+    ></Checkbox>
+
   </div>
 </template>
 

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -255,6 +255,8 @@
     "enable_discovery_desc": "When disabled, you'll need to manually enter host IP on the client to pair.",
     "enable_input_only_mode": "Enable Input Only Mode",
     "enable_input_only_mode_desc": "Add an Input Only app entry. When enabled, the app list will only show the current running app and the Input Only entry when streaming. The Input Only entry will not receive any image or audio. Useful for operating the desktop on TV or connecting peripherals which the TV doesn't support with a phone.",
+    "enable_block_rumble_messages_to_controllers": "Block Rumble Messages to Controllers",
+    "enable_block_rumble_messages_to_controllers_desc": "Block Rumble Messages to Controllers",
     "enable_pairing": "Enable Pairing",
     "enable_pairing_desc": "Enable pairing for the Moonlight client. This allows the client to authenticate with the host and establish a secure connection.",
     "encoder": "Force a Specific Encoder",


### PR DESCRIPTION
Feature: Added option to disable rumble on controllers from the Apollo side

Use case:
Some users do not always like the rumble functionality and it can interfere with their game play. Disabling the rumble function on a case-by-case system/phone/game/etc basis can be difficult especially for non-technical users or trying to quickly set things up.

Feature:
In the Configuration->Input tab, there is the option to block the rumble functionality. The default is to not disable this functionality (i.e. false). Essentially nothing is done in the rumble() function when it is blocked (i.e. enabled/true).
 