### PR TITLE
Correct frame timestamp initialization and update logic

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2013,7 +2013,12 @@ namespace video {
       if (!requested_idr_frame || images->peek()) {
         if (auto img = images->pop(max_frametime)) {
           frame_timestamp = img->frame_timestamp;
-          auto time_diff = *frame_timestamp - encode_frame_timestamp;
+          if (!frame_timestamp) {
+            frame_timestamp = std::chrono::steady_clock::now();
+          }
+
+          auto current_timestamp = *frame_timestamp;
+          auto time_diff = current_timestamp - encode_frame_timestamp;
 
           // If new frame comes in way too fast, just drop
           if (time_diff < -frame_variation_threshold) {
@@ -2028,7 +2033,7 @@ namespace video {
           if (time_diff < frame_variation_threshold) {
             *frame_timestamp = encode_frame_timestamp;
           } else {
-            encode_frame_timestamp = *frame_timestamp;
+            encode_frame_timestamp = current_timestamp;
           }
 
           encode_frame_timestamp += encode_frame_threshold;


### PR DESCRIPTION
Apollo crashed in my Manjaro KDE system on video streaming start with `_Optional_base::_M_get` because the encode loop assumed every captured frame supplied a timestamp.
```
 /usr/lib/gcc/x86_64-pc-linux-gnu/14.3.1/include/c++/optional:475: constexpr _Tp& std::_Optional_base_impl<_Tp, _Dp>::_M_get() [with _Tp = std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >; _Dp = std::_Optional_base<std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >, true, true>]: Assertion 'this->_M_is_engaged()' failed.
```
Some capture paths leave `img->frame_timestamp` disengaged, which led to the optional assertion when we tried to compute the pacing delta.

Fill in missing timestamps with `std::chrono::steady_clock::now()` and carry that value through the existing frame pacing logic so we keep a monotonic timeline without aborting the session.
