### PR TITLE
updated API documentation by adding info about accessing auth endpoint an…

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,19 +1,81 @@
 # API
 
-Sunshine has a RESTful API which can be used to interact with the service.
+Sunshine/Apollo has a RESTful API which can be used to interact with the service.
 
-Unless otherwise specified, authentication is required for all API calls. You can authenticate using
-basic authentication with the admin username and password.
+Unless otherwise specified, authentication is required for all API calls. You can authenticate using the
+`/api/login` endpoint with the admin username and password.
 
 @htmlonly
 <script src="api.js"></script>
 @endhtmlonly
 
+## POST /api/login
+Authenticates the admin account and issues a new `auth` session cookie.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| username | string | Yes |
+| password | string | Yes |
+
+| Description | Input |
+| --- | --- |
+| Minimal JSON payload | `{"username":"admin","password":"secret"}` |
+| curl example | ``curl -k -X POST https://localhost:47990/api/login -H "Content-Type: application/json" -d '{"username":"admin","password":"secret"}'`` |
+
+| Description | Status Code | Example Output |
+| --- | --- | --- |
+| Happy path | 200 | *(empty body; response includes `Set-Cookie: auth=<token>`)* |
+| Unauthorized | 401 | `{"status_code":401,"status":false,"error":"Unauthorized"}` |
+| Invalid JSON payload | 500 | *(empty body)*  |
+
+
 ## GET /api/apps
-@copydoc confighttp::getApps()
+Returns the configured apps list along with host metadata and the currently running app, if any.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| Cookie: auth | string | Yes |
+
+| Description | Input |
+| --- | --- |
+| curl example | ``curl -k -b "auth=<token>" https://localhost:47990/api/apps`` |
+| PowerShell (excerpt) | ``Invoke-WebRequest -Uri "$BaseUrl/api/apps" -WebSession $session`` |
+
+| Description | Status Code | Example Output |
+| --- | --- | --- |
+| Happy path | 200 | `{"apps":[{"name":"Steam","uuid":"aaaa-bbbb"}],"current_app":"","host_uuid":"HOST-123","host_name":"Sunshine"}` |
+| Unauthorized | 401 | `{"status_code":401,"status":false,"error":"Unauthorized"}` |
+| Apps file unreadable | 400 | `{"status_code":400,"status":false,"error":"Bad Request"}` |
 
 ## POST /api/apps
-@copydoc confighttp::saveApp()
+Creates a new app entry or updates an existing one in the Sunshine configuration.
+
+| Field | Type | Required |
+| --- | --- | --- |
+| Cookie: auth | string | Yes |
+| name | string | Yes |
+| cmd | string | Yes |
+| uuid | string | No (required when updating an existing app) |
+| output | string | No |
+| exclude-global-prep-cmd | boolean | No |
+| elevated | boolean | No |
+| auto-detach | boolean | No |
+| wait-all | boolean | No |
+| exit-timeout | number | No |
+| prep-cmd | array<object> | No |
+| detached | array<string> | No |
+| image-path | string (PNG path) | No |
+
+| Description | Input |
+| --- | --- |
+| Create minimal app | `{"name":"Steam","cmd":"C:\\\\Program Files\\\\Steam\\\\Steam.exe"}` |
+| Update existing app | `{"uuid":"aaaa-bbbb","name":"Steam (VR)","cmd":"C:\\\\Program Files\\\\SteamVR.exe"}` |
+
+| Description | Status Code | Example Output |
+| --- | --- | --- |
+| Happy path | 200 | `{"status":true}` |
+| Unauthorized | 401 | `{"status_code":401,"status":false,"error":"Unauthorized"}` |
+| Invalid payload (e.g., malformed JSON) | 400 | `{"status_code":400,"status":false,"error":"Bad Request"}` |
 
 ## POST /api/apps/close
 @copydoc confighttp::closeApp()


### PR DESCRIPTION
…d apps endpoints.

This is just a documentation update for the endpoints i ended up testing. I noticed that the documentation still reflected what OG sunshine has. 

Based on what @ClassicOldSong  suggested under [https://github.com/ClassicOldSong/Apollo/issues/1200](url) this issue, i tested the auth endpoint and the GET and POST apps endpoints and updated the usage documentation 

I did not test any others as i have not needed to for my automation just yet.  when i do though i will create another PR

My automation im working on uses powershell so the example usages are based on that