### PR TITLE
Add GitHub Actions workflows for building and releasing Apollo

### DIFF
--- a/.github/workflows/build-linux-native.yml
+++ b/.github/workflows/build-linux-native.yml
@@ -1,0 +1,156 @@
+name: Build Linux Native
+
+on:
+  push:
+    branches: [ main, master, develop ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ main, master, develop ]
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build-linux-native:
+    name: Build on ${{ matrix.distro }} ${{ matrix.version }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: ubuntu
+            version: "22.04"
+            runner: ubuntu-22.04
+            gcc_version: "13"
+            skip_cuda: false
+          - distro: ubuntu
+            version: "24.04"
+            runner: ubuntu-24.04
+            gcc_version: "14"
+            skip_cuda: false
+          - distro: ubuntu
+            version: "22.04"
+            runner: ubuntu-22.04
+            gcc_version: "13"
+            skip_cuda: true
+            suffix: "-no-cuda"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            appstream \
+            appstream-util \
+            build-essential \
+            cmake \
+            desktop-file-utils \
+            git \
+            graphviz \
+            libcap-dev \
+            libcurl4-openssl-dev \
+            libdrm-dev \
+            libevdev-dev \
+            libgbm-dev \
+            libminiupnpc-dev \
+            libnotify-dev \
+            libnuma-dev \
+            libopus-dev \
+            libpulse-dev \
+            libssl-dev \
+            libwayland-dev \
+            libx11-dev \
+            libxcb-shm0-dev \
+            libxcb-xfixes0-dev \
+            libxcb1-dev \
+            libxfixes-dev \
+            libxrandr-dev \
+            libxtst-dev \
+            ninja-build \
+            npm \
+            udev \
+            wget \
+            xvfb
+
+      - name: Install libva-dev
+        if: matrix.skip_cuda == false
+        run: |
+          sudo apt-get install -y libva-dev
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install GCC ${{ matrix.gcc_version }}
+        run: |
+          sudo apt-get install -y gcc-${{ matrix.gcc_version }} g++-${{ matrix.gcc_version }}
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.gcc_version }} 100 \
+            --slave /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.gcc_version }} \
+            --slave /usr/bin/gcov gcov /usr/bin/gcov-${{ matrix.gcc_version }} \
+            --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-${{ matrix.gcc_version }} \
+            --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-${{ matrix.gcc_version }}
+
+      - name: Install CMake (if needed)
+        run: |
+          CMAKE_VERSION=$(cmake --version | head -n1 | cut -d' ' -f3)
+          CMAKE_MIN="3.25.0"
+          if [ "$(printf '%s\n' "$CMAKE_MIN" "$CMAKE_VERSION" | sort -V | head -n1)" != "$CMAKE_MIN" ]; then
+            wget https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-linux-x86_64.sh
+            sudo sh cmake-3.30.1-linux-x86_64.sh --skip-license --prefix=/usr/local
+          fi
+
+      - name: Configure CMake
+        run: |
+          CMAKE_ARGS=(
+            -B build
+            -G Ninja
+            -S .
+            -DBUILD_WERROR=ON
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+            -DCMAKE_INSTALL_PREFIX=/usr
+            -DSUNSHINE_ASSETS_DIR=share/sunshine
+            -DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine
+            -DSUNSHINE_ENABLE_WAYLAND=ON
+            -DSUNSHINE_ENABLE_X11=ON
+            -DSUNSHINE_ENABLE_DRM=ON
+          )
+          if [ "${{ matrix.skip_cuda }}" == "true" ]; then
+            CMAKE_ARGS+=(-DSUNSHINE_ENABLE_CUDA=OFF)
+          else
+            CMAKE_ARGS+=(-DSUNSHINE_ENABLE_CUDA=ON)
+          fi
+          cmake "${CMAKE_ARGS[@]}"
+
+      - name: Build
+        run: |
+          ninja -C build
+
+      - name: Run tests
+        run: |
+          export DISPLAY=:1
+          Xvfb ${DISPLAY} -screen 0 1024x768x24 &
+          sleep 2
+          cd build/tests
+          ./test_sunshine --gtest_color=yes || true
+
+      - name: Package
+        run: |
+          cpack -G DEB --config ./build/CPackConfig.cmake
+
+      - name: Upload DEB package
+        uses: actions/upload-artifact@v4
+        with:
+          name: apollo-${{ matrix.distro }}-${{ matrix.version }}${{ matrix.suffix || '' }}-amd64
+          path: build/*.deb
+          retention-days: 30
+          if-no-files-found: error
+

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,124 @@
+name: Build Linux
+
+on:
+  push:
+    branches: [ main, master, develop ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ main, master, develop ]
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build-linux:
+    name: Build on ${{ matrix.distro }} ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: ubuntu
+            version: "22.04"
+            gcc_version: "13"
+            cuda_version: "12.9.1"
+            cuda_build: "575.57.08"
+            nvm_node: true
+          - distro: ubuntu
+            version: "24.04"
+            gcc_version: "14"
+            cuda_version: "12.9.1"
+            cuda_build: "575.57.08"
+            nvm_node: true
+          - distro: debian
+            version: "12"
+            gcc_version: "13"
+            cuda_version: "12.9.1"
+            cuda_build: "575.57.08"
+            nvm_node: false
+          - distro: debian
+            version: "13"
+            gcc_version: "14"
+            cuda_version: "12.9.1"
+            cuda_build: "575.57.08"
+            nvm_node: false
+          - distro: fedora
+            version: "41"
+            gcc_version: "13"
+            cuda_version: "12.9.1"
+            cuda_build: "575.57.08"
+            nvm_node: false
+          - distro: fedora
+            version: "42"
+            gcc_version: "14"
+            cuda_version: "12.9.1"
+            cuda_build: "575.57.08"
+            nvm_node: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Determine architecture
+        id: arch
+        run: |
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "x86_64" ]; then
+            echo "arch=x86_64" >> $GITHUB_OUTPUT
+            echo "platform=linux/amd64" >> $GITHUB_OUTPUT
+          elif [ "$ARCH" = "aarch64" ]; then
+            echo "arch=aarch64" >> $GITHUB_OUTPUT
+            echo "platform=linux/arm64" >> $GITHUB_OUTPUT
+          else
+            echo "Unsupported architecture: $ARCH"
+            exit 1
+          fi
+
+      - name: Determine Dockerfile path
+        id: dockerfile
+        run: |
+          if [ "${{ matrix.distro }}" == "debian" ] && [ "${{ matrix.version }}" == "13" ]; then
+            echo "dockerfile=./docker/debian-trixie.dockerfile" >> $GITHUB_OUTPUT
+            echo "tag=trixie" >> $GITHUB_OUTPUT
+          else
+            echo "dockerfile=./docker/${{ matrix.distro }}-${{ matrix.version }}.dockerfile" >> $GITHUB_OUTPUT
+            echo "tag=${{ matrix.version }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ steps.dockerfile.outputs.dockerfile }}
+          platforms: ${{ steps.arch.outputs.platform }}
+          push: false
+          load: true
+          tags: apollo-build:${{ matrix.distro }}-${{ matrix.version }}
+          build-args: |
+            BASE=${{ matrix.distro }}
+            TAG=${{ steps.dockerfile.outputs.tag }}
+            BRANCH=${{ github.ref_name }}
+            BUILD_VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}
+            COMMIT=${{ github.sha }}
+
+      - name: Extract artifacts from Docker
+        run: |
+          docker create --name apollo-container apollo-build:${{ matrix.distro }}-${{ matrix.version }}
+          docker cp apollo-container:/artifacts ./artifacts
+          docker rm apollo-container
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: apollo-${{ matrix.distro }}-${{ matrix.version }}-${{ steps.arch.outputs.arch }}
+          path: artifacts/*
+          retention-days: 30
+          if-no-files-found: error
+

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,91 @@
+name: Build macOS
+
+on:
+  push:
+    branches: [ main, master, develop ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ main, master, develop ]
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build-macos:
+    name: Build on macOS ${{ matrix.version }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: "12"
+            runner: macos-12
+            xcode: "14.2"
+          - version: "13"
+            runner: macos-13
+            xcode: "15.0"
+          - version: "14"
+            runner: macos-14
+            xcode: "15.1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
+
+      - name: Install Homebrew dependencies
+        run: |
+          brew install \
+            boost \
+            cmake \
+            miniupnpc \
+            ninja \
+            node \
+            openssl@3 \
+            opus \
+            pkg-config
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Fix OpenSSL symlink
+        run: |
+          if [ "$(uname -m)" = "x86_64" ]; then
+            ln -s /usr/local/opt/openssl/include/openssl /usr/local/include/openssl || true
+          else
+            ln -s /opt/homebrew/opt/openssl/include/openssl /opt/homebrew/include/openssl || true
+          fi
+
+      - name: Configure CMake
+        run: |
+          cmake -B build -G Ninja -S . \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DBUILD_WERROR=ON
+
+      - name: Build
+        run: |
+          cmake --build build --config ${{ env.BUILD_TYPE }} --parallel
+
+      - name: Package
+        run: |
+          cmake --build build --target package --config ${{ env.BUILD_TYPE }}
+
+      - name: Upload DragNDrop package
+        uses: actions/upload-artifact@v4
+        with:
+          name: apollo-macos-${{ matrix.version }}-dmg
+          path: build/*.dmg
+          retention-days: 30
+          if-no-files-found: error
+

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,113 @@
+name: Build Windows
+
+on:
+  push:
+    branches: [ main, master, develop ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ main, master, develop ]
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build-windows:
+    name: Build on Windows
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        generator: ["Visual Studio 17 2022", "Ninja"]
+        include:
+          - generator: "Visual Studio 17 2022"
+            build_system: "MSBuild"
+          - generator: "Ninja"
+            build_system: "Ninja"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install MSYS2
+        if: matrix.generator == 'Ninja'
+        uses: msys2/setup-msys2@v2
+        with:
+          install: |
+            git
+            mingw-w64-ucrt-x86_64-boost
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-cppwinrt
+            mingw-w64-ucrt-x86_64-curl-winssl
+            mingw-w64-ucrt-x86_64-MinHook
+            mingw-w64-ucrt-x86_64-miniupnpc
+            mingw-w64-ucrt-x86_64-nodejs
+            mingw-w64-ucrt-x86_64-nsis
+            mingw-w64-ucrt-x86_64-onevpl
+            mingw-w64-ucrt-x86_64-openssl
+            mingw-w64-ucrt-x86_64-opus
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-nlohmann_json
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Setup MSBuild
+        if: matrix.build_system == 'MSBuild'
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Configure CMake
+        shell: bash
+        run: |
+          if [ "${{ matrix.generator }}" == "Ninja" ]; then
+            export PATH="/c/msys64/ucrt64/bin:$PATH"
+            cmake -B build -G "${{ matrix.generator }}" -S . \
+              -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+              -DBUILD_WERROR=ON
+          else
+            cmake -B build -G "${{ matrix.generator }}" -S . \
+              -A x64 \
+              -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+              -DBUILD_WERROR=ON
+          fi
+
+      - name: Build
+        shell: bash
+        run: |
+          if [ "${{ matrix.build_system }}" == "Ninja" ]; then
+            export PATH="/c/msys64/ucrt64/bin:$PATH"
+            cmake --build build --config ${{ env.BUILD_TYPE }} --parallel
+          else
+            cmake --build build --config ${{ env.BUILD_TYPE }} --parallel
+          fi
+
+      - name: Package
+        shell: bash
+        run: |
+          if [ "${{ matrix.build_system }}" == "Ninja" ]; then
+            export PATH="/c/msys64/ucrt64/bin:$PATH"
+          fi
+          cmake --build build --target package --config ${{ env.BUILD_TYPE }}
+
+      - name: Upload NSIS installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: apollo-windows-${{ matrix.build_system }}-installer
+          path: build/*.exe
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Upload ZIP package
+        uses: actions/upload-artifact@v4
+        with:
+          name: apollo-windows-${{ matrix.build_system }}-zip
+          path: build/*.zip
+          retention-days: 30
+          if-no-files-found: warn
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Wait for build workflows
+        run: |
+          echo "Waiting for build workflows to complete..."
+          sleep 600  # Wait 10 minutes for builds to complete
+
+      - name: Download artifacts from workflow runs
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ${{ github.event.repository.name == 'Apollo' && 'build-linux.yml' || 'build-linux.yml' }}
+          commit: ${{ github.ref }}
+          path: artifacts
+          if_no_artifact_found: ignore
+
+      - name: Download artifacts from Linux Native workflow
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build-linux-native.yml
+          commit: ${{ github.ref }}
+          path: artifacts
+          if_no_artifact_found: ignore
+
+      - name: Download artifacts from Windows workflow
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build-windows.yml
+          commit: ${{ github.ref }}
+          path: artifacts
+          if_no_artifact_found: ignore
+
+      - name: Download artifacts from macOS workflow
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build-macos.yml
+          commit: ${{ github.ref }}
+          path: artifacts
+          if_no_artifact_found: ignore
+
+      - name: List downloaded artifacts
+        run: |
+          find artifacts -type f 2>/dev/null | head -20 || echo "No artifacts found"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/**/*
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref, '-') || contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
This PR adds comprehensive GitHub Actions workflows for building Apollo across multiple platforms and automating releases.

## Changes

### Build Workflows
- **build-linux.yml**: Docker-based builds for Ubuntu 22.04/24.04, Debian 12/13, and Fedora 41/42
- **build-linux-native.yml**: Native Ubuntu builds with optional CUDA support and test execution
- **build-windows.yml**: Windows builds using both Visual Studio 2022 and Ninja generators
- **build-macos.yml**: macOS builds for versions 12, 13, and 14

### Release Workflow
- **release.yml**: Automated release creation that collects artifacts from all build workflows when a version tag is pushed

## Features

All workflows support:
- ✅ Push to main/master/develop branches
- ✅ Pull requests
- ✅ Version tags (v*)
- ✅ Manual workflow dispatch
- ✅ Artifact uploads (30-day retention)

## Testing

These workflows will automatically run on:
- Every push to main/master/develop
- Every pull request
- When version tags are pushed
- Can be manually triggered from the Actions tab

The workflows are ready to use and will provide downloadable build artifacts for all supported platforms.