### PR TITLE
Add GitHub Actions workflows for Docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,374 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+    inputs:
+      dockerfile:
+        description: 'Dockerfile to build'
+        required: false
+        type: choice
+        options:
+          - all
+          - archlinux
+          - debian-trixie
+          - ubuntu-22.04
+          - ubuntu-24.04
+      platform:
+        description: 'Platform to build for'
+        required: false
+        type: choice
+        options:
+          - all
+          - linux/amd64
+          - linux/arm64/v8
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-archlinux:
+    name: Build Arch Linux
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' && 
+      (github.event.inputs.dockerfile == 'all' || github.event.inputs.dockerfile == 'archlinux') ||
+      github.event_name != 'workflow_dispatch'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=archlinux,enable={{is_default_branch}}
+
+      - name: Set build arguments
+        id: build-args
+        run: |
+          echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "COMMIT=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "BUILD_VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}" >> $GITHUB_OUTPUT
+          echo "CLONE_URL=${{ github.server_url }}/${{ github.repository }}" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/archlinux.dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}-archlinux
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BRANCH=${{ steps.build-args.outputs.BRANCH }}
+            COMMIT=${{ steps.build-args.outputs.COMMIT }}
+            BUILD_VERSION=${{ steps.build-args.outputs.BUILD_VERSION }}
+            CLONE_URL=${{ steps.build-args.outputs.CLONE_URL }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=/tmp/archlinux-image.tar
+
+      - name: Extract artifacts
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p ./artifacts-archlinux
+          docker load -i /tmp/archlinux-image.tar
+          IMAGE_TAG=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep archlinux | head -1)
+          CONTAINER_ID=$(docker create $IMAGE_TAG)
+          docker cp $CONTAINER_ID:/artifacts/. ./artifacts-archlinux/ || true
+          docker rm $CONTAINER_ID
+          ls -la ./artifacts-archlinux/ || true
+
+      - name: Upload artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: archlinux-artifacts
+          path: artifacts-archlinux/*
+          retention-days: 30
+
+  build-debian-trixie:
+    name: Build Debian Trixie
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64/v8
+    if: |
+      github.event_name == 'workflow_dispatch' && 
+      (github.event.inputs.dockerfile == 'all' || github.event.inputs.dockerfile == 'debian-trixie') &&
+      (github.event.inputs.platform == 'all' || github.event.inputs.platform == matrix.platform) ||
+      (github.event_name != 'workflow_dispatch' && (matrix.platform == 'linux/amd64' || github.event_name == 'push'))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=debian-trixie,enable={{is_default_branch}}
+
+      - name: Set build arguments
+        id: build-args
+        run: |
+          echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "COMMIT=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "BUILD_VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/debian-trixie.dockerfile
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}-debian-trixie
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BRANCH=${{ steps.build-args.outputs.BRANCH }}
+            COMMIT=${{ steps.build-args.outputs.COMMIT }}
+            BUILD_VERSION=${{ steps.build-args.outputs.BUILD_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=/tmp/debian-trixie-${{ matrix.platform }}.tar
+
+      - name: Extract artifacts
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p ./artifacts-debian-trixie-${{ matrix.platform }}
+          docker load -i /tmp/debian-trixie-${{ matrix.platform }}.tar
+          IMAGE_TAG=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep debian-trixie | head -1)
+          CONTAINER_ID=$(docker create $IMAGE_TAG)
+          docker cp $CONTAINER_ID:/artifacts/. ./artifacts-debian-trixie-${{ matrix.platform }}/ || true
+          docker rm $CONTAINER_ID
+          ls -la ./artifacts-debian-trixie-${{ matrix.platform }}/ || true
+
+      - name: Upload artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-trixie-artifacts-${{ matrix.platform }}
+          path: artifacts-debian-trixie-${{ matrix.platform }}/*
+          retention-days: 30
+
+  build-ubuntu-22.04:
+    name: Build Ubuntu 22.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64/v8
+    if: |
+      github.event_name == 'workflow_dispatch' && 
+      (github.event.inputs.dockerfile == 'all' || github.event.inputs.dockerfile == 'ubuntu-22.04') &&
+      (github.event.inputs.platform == 'all' || github.event.inputs.platform == matrix.platform) ||
+      (github.event_name != 'workflow_dispatch' && (matrix.platform == 'linux/amd64' || github.event_name == 'push'))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=ubuntu-22.04,enable={{is_default_branch}}
+
+      - name: Set build arguments
+        id: build-args
+        run: |
+          echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "COMMIT=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "BUILD_VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/ubuntu-22.04.dockerfile
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}-ubuntu-22.04
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BRANCH=${{ steps.build-args.outputs.BRANCH }}
+            COMMIT=${{ steps.build-args.outputs.COMMIT }}
+            BUILD_VERSION=${{ steps.build-args.outputs.BUILD_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=/tmp/ubuntu-22.04-${{ matrix.platform }}.tar
+
+      - name: Extract artifacts
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p ./artifacts-ubuntu-22.04-${{ matrix.platform }}
+          docker load -i /tmp/ubuntu-22.04-${{ matrix.platform }}.tar
+          IMAGE_TAG=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep ubuntu-22.04 | head -1)
+          CONTAINER_ID=$(docker create $IMAGE_TAG)
+          docker cp $CONTAINER_ID:/artifacts/. ./artifacts-ubuntu-22.04-${{ matrix.platform }}/ || true
+          docker rm $CONTAINER_ID
+          ls -la ./artifacts-ubuntu-22.04-${{ matrix.platform }}/ || true
+
+      - name: Upload artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu-22.04-artifacts-${{ matrix.platform }}
+          path: artifacts-ubuntu-22.04-${{ matrix.platform }}/*
+          retention-days: 30
+
+  build-ubuntu-24.04:
+    name: Build Ubuntu 24.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64/v8
+    if: |
+      github.event_name == 'workflow_dispatch' && 
+      (github.event.inputs.dockerfile == 'all' || github.event.inputs.dockerfile == 'ubuntu-24.04') &&
+      (github.event.inputs.platform == 'all' || github.event.inputs.platform == matrix.platform) ||
+      (github.event_name != 'workflow_dispatch' && (matrix.platform == 'linux/amd64' || github.event_name == 'push'))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=ubuntu-24.04,enable={{is_default_branch}}
+
+      - name: Set build arguments
+        id: build-args
+        run: |
+          echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "COMMIT=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "BUILD_VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/ubuntu-24.04.dockerfile
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}-ubuntu-24.04
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BRANCH=${{ steps.build-args.outputs.BRANCH }}
+            COMMIT=${{ steps.build-args.outputs.COMMIT }}
+            BUILD_VERSION=${{ steps.build-args.outputs.BUILD_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=/tmp/ubuntu-24.04-${{ matrix.platform }}.tar
+
+      - name: Extract artifacts
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p ./artifacts-ubuntu-24.04-${{ matrix.platform }}
+          docker load -i /tmp/ubuntu-24.04-${{ matrix.platform }}.tar
+          IMAGE_TAG=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep ubuntu-24.04 | head -1)
+          CONTAINER_ID=$(docker create $IMAGE_TAG)
+          docker cp $CONTAINER_ID:/artifacts/. ./artifacts-ubuntu-24.04-${{ matrix.platform }}/ || true
+          docker rm $CONTAINER_ID
+          ls -la ./artifacts-ubuntu-24.04-${{ matrix.platform }}/ || true
+
+      - name: Upload artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu-24.04-artifacts-${{ matrix.platform }}
+          path: artifacts-ubuntu-24.04-${{ matrix.platform }}/*
+          retention-days: 30

--- a/.github/workflows/docker-clion-toolchain.yml
+++ b/.github/workflows/docker-clion-toolchain.yml
@@ -1,0 +1,68 @@
+name: Docker CLion Toolchain
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - 'docker/clion-toolchain.dockerfile'
+      - '.github/workflows/docker-clion-toolchain.yml'
+  pull_request:
+    branches:
+      - master
+      - main
+    paths:
+      - 'docker/clion-toolchain.dockerfile'
+      - '.github/workflows/docker-clion-toolchain.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-clion-toolchain:
+    name: Build CLion Toolchain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-
+            type=raw,value=clion-toolchain,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/clion-toolchain.dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}-clion-toolchain
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
This PR adds GitHub Actions workflows to automatically build Docker images for all Dockerfiles in the `docker/` directory.

## Changes
- **docker-build.yml**: Main workflow for building package images
  - Arch Linux (amd64 only)
  - Debian Trixie (amd64, arm64)
  - Ubuntu 22.04 (amd64, arm64)
  - Ubuntu 24.04 (amd64, arm64)
  
- **docker-clion-toolchain.yml**: Workflow for CLion development toolchain (amd64)

## Features
- ✅ Multi-platform builds where supported
- ✅ Automatic artifact extraction and upload (.deb, .pkg.tar.zst files)
- ✅ Build argument support (BRANCH, COMMIT, BUILD_VERSION, CLONE_URL)
- ✅ Docker layer caching for faster builds
- ✅ Automatic tagging and publishing to GitHub Container Registry
- ✅ Manual workflow dispatch with options
- ✅ Conditional builds (PRs build but don't push)

## Triggers
- Push to master/main
- Tags (v*)
- Pull requests
- Manual workflow dispatch

The workflows are ready to use and will automatically build Docker images when changes are pushed to the repository.