### PR TITLE
Update Boost 1.89.0 hash

### DIFF
--- a/cmake/dependencies/Boost_Sunshine.cmake
+++ b/cmake/dependencies/Boost_Sunshine.cmake
@@ -55,7 +55,7 @@ if(NOT Boost_FOUND)
     # Limit boost to the required libraries only
     set(BOOST_INCLUDE_LIBRARIES ${BOOST_COMPONENTS})
     set(BOOST_URL "https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-cmake.tar.xz")  # cmake-lint: disable=C0301
-    set(BOOST_HASH "SHA256=f48b48390380cfb94a629872346e3a81370dc498896f16019ade727ab72eb1ec")
+    set(BOOST_HASH "SHA256=67acec02d0d118b5de9eb441f5fb707b3a1cdd884be00ca24b9a73c995511f74")
 
     if(CMAKE_VERSION VERSION_LESS "3.24.0")
         FetchContent_Declare(


### PR DESCRIPTION
Commit db4c2fab updated the version to 1.89.0 but forgot to update the SHA256 hash, causing build failures.

```
curl -sL https://github.com/boostorg/boost/releases/download/boost-1.89.0/boost-1.89.0-cmake.tar.xz | sha256sum
67acec02d0d118b5de9eb441f5fb707b3a1cdd884be00ca24b9a73c995511f74
```