### PR TITLE
feat: Add client-side cursor support

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -461,6 +461,7 @@ namespace nvhttp {
     launch_session->enable_hdr = util::from_view(get_arg(args, "hdrMode", "0"));
     launch_session->virtual_display = util::from_view(get_arg(args, "virtualDisplay", "0")) || named_cert_p->always_use_virtual_display;
     launch_session->scale_factor = util::from_view(get_arg(args, "scaleFactor", "100"));
+    launch_session->clientSideCursor = util::from_view(get_arg(args, "clientSideCursor", "0"));
 
     launch_session->client_do_cmds = named_cert_p->do_cmds;
     launch_session->client_undo_cmds = named_cert_p->undo_cmds;

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -618,6 +618,10 @@ namespace platf {
   void streaming_will_start();
   void streaming_will_stop();
 
+  // Client-side cursor support (Windows only, no-op on other platforms)
+  void client_side_cursor_session_start();
+  void client_side_cursor_session_stop();
+
   void restart();
 
   /**

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -371,6 +371,14 @@ std::string get_local_ip_for_gateway() {
     // Nothing to do
   }
 
+  void client_side_cursor_session_start() {
+    // Not implemented on Linux - cursor hiding would need X11/Wayland specific code
+  }
+
+  void client_side_cursor_session_stop() {
+    // Not implemented on Linux
+  }
+
   void restart_on_exit() {
     char executable[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", executable, PATH_MAX - 1);

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -227,6 +227,14 @@ namespace platf {
     // Nothing to do
   }
 
+  void client_side_cursor_session_start() {
+    // Not implemented on macOS
+  }
+
+  void client_side_cursor_session_stop() {
+    // Not implemented on macOS
+  }
+
   void restart_on_exit() {
     char executable[2048];
     uint32_t size = sizeof(executable);

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -4,6 +4,7 @@
  */
 // standard includes
 #include <csignal>
+#include <cstdlib>
 #include <filesystem>
 #include <iomanip>
 #include <iterator>
@@ -69,6 +70,23 @@
   #define WLAN_API_MAKE_VERSION(_major, _minor) (((DWORD) (_minor)) << 16 | (_major))
 #endif
 
+// OCR_* cursor IDs are missing from MinGW headers
+#ifndef OCR_NORMAL
+  #define OCR_NORMAL      32512
+  #define OCR_IBEAM       32513
+  #define OCR_WAIT        32514
+  #define OCR_CROSS       32515
+  #define OCR_UP          32516
+  #define OCR_SIZENWSE    32642
+  #define OCR_SIZENESW    32643
+  #define OCR_SIZEWE      32644
+  #define OCR_SIZENS      32645
+  #define OCR_SIZEALL     32646
+  #define OCR_NO          32648
+  #define OCR_HAND        32649
+  #define OCR_APPSTARTING 32650
+#endif
+
 #include <winternl.h>
 extern "C" {
   NTSTATUS NTAPI NtSetTimerResolution(ULONG DesiredResolution, BOOLEAN SetResolution, PULONG CurrentResolution);
@@ -111,6 +129,48 @@ namespace platf {
 
   bool enabled_mouse_keys = false;
   MOUSEKEYS previous_mouse_keys_state;
+
+  // Client-side cursor support: transparent cursor state
+  bool client_side_cursor_active = false;
+  std::atomic<int> client_side_cursor_sessions{0};  // Count of sessions requesting client-side cursor
+  bool cursor_crash_handler_registered = false;
+
+  // Store original system cursors to restore later
+  struct saved_cursor_t {
+    HCURSOR cursor;
+    bool saved;
+  };
+  // OCR_* cursor IDs to save/restore
+  constexpr DWORD cursor_ids[] = {
+    OCR_NORMAL, OCR_IBEAM, OCR_WAIT, OCR_CROSS, OCR_UP,
+    OCR_SIZENWSE, OCR_SIZENESW, OCR_SIZEWE, OCR_SIZENS, OCR_SIZEALL,
+    OCR_NO, OCR_HAND, OCR_APPSTARTING
+  };
+  saved_cursor_t saved_cursors[sizeof(cursor_ids) / sizeof(cursor_ids[0])];
+  HCURSOR transparent_cursor = nullptr;
+
+  /**
+   * @brief Emergency cursor restoration - resets all cursors to system defaults.
+   * This is called on crash/unexpected termination to ensure user doesn't lose their cursor.
+   */
+  void emergency_restore_cursors() {
+    if (client_side_cursor_active) {
+      // Reset all cursors to system defaults - this is the nuclear option but guaranteed to work
+      SystemParametersInfoW(SPI_SETCURSORS, 0, nullptr, 0);
+      client_side_cursor_active = false;
+    }
+  }
+
+  // Crash handler for cursor restoration
+  static LONG WINAPI cursor_crash_handler(EXCEPTION_POINTERS* exceptionInfo) {
+    emergency_restore_cursors();
+    return EXCEPTION_CONTINUE_SEARCH;  // Let other handlers process the exception
+  }
+
+  // atexit handler for cursor restoration
+  static void cursor_atexit_handler() {
+    emergency_restore_cursors();
+  }
 
   HANDLE qos_handle = nullptr;
 
@@ -1102,6 +1162,122 @@ namespace platf {
     if (!SetThreadPriority(GetCurrentThread(), win32_priority)) {
       auto winerr = GetLastError();
       BOOST_LOG(warning) << "Unable to set thread priority to "sv << win32_priority << ": "sv << winerr;
+    }
+  }
+
+  /**
+   * @brief Creates a fully transparent cursor.
+   * @return Handle to the transparent cursor, or nullptr on failure.
+   */
+  HCURSOR create_transparent_cursor() {
+    // Create a 1x1 transparent cursor
+    constexpr int width = 1;
+    constexpr int height = 1;
+
+    // AND mask: all 1s (transparent where AND with screen)
+    BYTE andMask[1] = {0xFF};
+    // XOR mask: all 0s (don't invert)
+    BYTE xorMask[1] = {0x00};
+
+    return CreateCursor(GetModuleHandle(nullptr), 0, 0, width, height, andMask, xorMask);
+  }
+
+  /**
+   * @brief Saves all current system cursors and replaces them with transparent ones.
+   * @return true on success.
+   */
+  bool enable_transparent_cursors() {
+    if (client_side_cursor_active) {
+      return true;  // Already active
+    }
+
+    // Create the transparent cursor if we haven't yet
+    if (!transparent_cursor) {
+      transparent_cursor = create_transparent_cursor();
+      if (!transparent_cursor) {
+        BOOST_LOG(error) << "Failed to create transparent cursor: "sv << GetLastError();
+        return false;
+      }
+    }
+
+    // Save and replace each system cursor
+    for (size_t i = 0; i < sizeof(cursor_ids) / sizeof(cursor_ids[0]); i++) {
+      // Copy the system cursor to save it
+      HCURSOR original = CopyCursor(LoadCursorW(nullptr, MAKEINTRESOURCEW(cursor_ids[i])));
+      if (original) {
+        saved_cursors[i].cursor = original;
+        saved_cursors[i].saved = true;
+
+        // Replace with transparent cursor (need to copy it for each SetSystemCursor call)
+        HCURSOR transparent_copy = CopyCursor(transparent_cursor);
+        if (transparent_copy) {
+          if (!SetSystemCursor(transparent_copy, cursor_ids[i])) {
+            BOOST_LOG(warning) << "Failed to set transparent cursor for ID "sv << cursor_ids[i] << ": "sv << GetLastError();
+          }
+        }
+      } else {
+        saved_cursors[i].saved = false;
+        BOOST_LOG(warning) << "Failed to copy cursor for ID "sv << cursor_ids[i] << ": "sv << GetLastError();
+      }
+    }
+
+    // Register crash handlers to ensure cursor restoration on unexpected termination
+    if (!cursor_crash_handler_registered) {
+      SetUnhandledExceptionFilter(cursor_crash_handler);
+      std::atexit(cursor_atexit_handler);
+      cursor_crash_handler_registered = true;
+      BOOST_LOG(debug) << "Registered cursor crash recovery handlers"sv;
+    }
+
+    client_side_cursor_active = true;
+    BOOST_LOG(info) << "Client-side cursor mode enabled: system cursors are now transparent"sv;
+    return true;
+  }
+
+  /**
+   * @brief Restores all original system cursors.
+   */
+  void disable_transparent_cursors() {
+    if (!client_side_cursor_active) {
+      return;  // Not active
+    }
+
+    // Restore each saved cursor
+    for (size_t i = 0; i < sizeof(cursor_ids) / sizeof(cursor_ids[0]); i++) {
+      if (saved_cursors[i].saved) {
+        // SetSystemCursor takes ownership, so no need to destroy after
+        if (!SetSystemCursor(saved_cursors[i].cursor, cursor_ids[i])) {
+          BOOST_LOG(warning) << "Failed to restore cursor for ID "sv << cursor_ids[i] << ": "sv << GetLastError();
+          // Destroy the cursor since SetSystemCursor failed
+          DestroyCursor(saved_cursors[i].cursor);
+        }
+        saved_cursors[i].saved = false;
+        saved_cursors[i].cursor = nullptr;
+      }
+    }
+
+    // Alternatively, reset all cursors to system defaults
+    // SystemParametersInfoW(SPI_SETCURSORS, 0, nullptr, SPIF_SENDCHANGE);
+
+    client_side_cursor_active = false;
+    BOOST_LOG(info) << "Client-side cursor mode disabled: system cursors restored"sv;
+  }
+
+  /**
+   * @brief Called when a session starts with client-side cursor enabled.
+   */
+  void client_side_cursor_session_start() {
+    if (++client_side_cursor_sessions == 1) {
+      enable_transparent_cursors();
+    }
+  }
+
+  /**
+   * @brief Called when a session ends that had client-side cursor enabled.
+   */
+  void client_side_cursor_session_stop() {
+    if (--client_side_cursor_sessions == 0) {
+      disable_transparent_cursors();
     }
   }
 

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -58,6 +58,8 @@ namespace rtsp_stream {
     std::list<crypto::command_entry_t> client_do_cmds;
     std::list<crypto::command_entry_t> client_undo_cmds;
 
+    bool clientSideCursor;  ///< If true, host should hide cursor (make transparent) for client-side rendering
+
   #ifdef _WIN32
     GUID display_guid{};
   #endif

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -419,6 +419,8 @@ namespace stream {
     std::list<crypto::command_entry_t> do_cmds;
     std::list<crypto::command_entry_t> undo_cmds;
 
+    bool clientSideCursor;  ///< If true, host cursor is transparent for client-side rendering
+
     safe::mail_raw_t::event_t<bool> shutdown_event;
     safe::signal_t controlEnd;
 
@@ -2047,6 +2049,11 @@ namespace stream {
       BOOST_LOG(debug) << "Resetting Input..."sv;
       input::reset(session.input);
 
+      // Disable client-side cursor mode if it was enabled for this session
+      if (session.clientSideCursor) {
+        platf::client_side_cursor_session_stop();
+      }
+
       if (!session.undo_cmds.empty()) {
         auto exec_thread = std::thread([cmd_list = session.undo_cmds]{
           for (auto &cmd : cmd_list) {
@@ -2123,6 +2130,11 @@ namespace stream {
         proc::proc.resume();
       }
 
+      // Enable client-side cursor mode if requested
+      if (session.clientSideCursor) {
+        platf::client_side_cursor_session_start();
+      }
+
       if (!session.do_cmds.empty()) {
         auto exec_thread = std::thread([cmd_list = session.do_cmds]{
           for (auto &cmd : cmd_list) {
@@ -2158,6 +2170,7 @@ namespace stream {
 
       session->do_cmds = std::move(launch_session.client_do_cmds);
       session->undo_cmds = std::move(launch_session.client_undo_cmds);
+      session->clientSideCursor = launch_session.clientSideCursor;
 
       session->config = config;
 


### PR DESCRIPTION
# Adds client-side cursor support (transparent host cursor)

## Problem

When streaming over high-latency connections (e.g., 150ms+), mouse input feels extremely sluggish because:
1. User moves mouse on client
2. Input is sent to host (~150ms)
3. Host moves cursor and renders frame
4. Frame is encoded and sent back to client (~150ms)
5. **Total: ~300ms delay before seeing cursor movement**

This makes the streaming experience nearly unusable for productivity work over long distances.

## Solution

This PR adds support for **client-side cursor rendering**:
- When enabled, the host makes its cursor **transparent** during the streaming session
- The client renders its own local cursor that responds instantly to mouse movement
- Mouse input is still sent to the host normally, so clicks work at the correct position
- On session end (or crash), the host cursor is automatically restored

## How it works

1. Client sends `clientSideCursor=1` parameter when launching a session
2. Host receives this and calls `client_side_cursor_session_start(true)`
3. Host saves all system cursors (OCR_NORMAL, OCR_IBEAM, OCR_WAIT, etc.)
4. Host replaces them with a 1x1 transparent cursor
5. On session end, host restores all original cursors

## Safety features

- **Crash recovery**: Uses `SetUnhandledExceptionFilter` to restore cursors if Apollo crashes
- **Session counting**: Supports multiple concurrent sessions correctly
- **Emergency restore**: `SystemParametersInfoW(SPI_SETCURSORS)` as nuclear fallback

## Files changed

- `src/rtsp.h` - Added `clientSideCursor` field to `launch_session_t`
- `src/nvhttp.cpp` - Parse `clientSideCursor` parameter from client
- `src/stream.cpp` - Call cursor functions on session start/end
- `src/platform/common.h` - Declare platform functions
- `src/platform/windows/misc.cpp` - Windows implementation
- `src/platform/linux/misc.cpp` - Stub (Linux support could be added later)
- `src/platform/macos/misc.mm` - Stub (macOS support could be added later)

## Companion PR

This feature requires a corresponding client-side PR to moonlight-qt (https://github.com/moonlight-stream/moonlight-qt/pull/1785) that:
- Adds the "Client-side cursor" setting
- Sends the `clientSideCursor` parameter to the host
- Shows the local cursor during streaming (uses absolute mouse mode)

## Testing

Tested on Windows 11 host with ~150ms latency to client. Mouse feels instant while maintaining click accuracy, no more sloppy movements.
