### PR TITLE
Fix headless mode: Set virtual display as primary automatically

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -325,6 +325,29 @@ namespace proc {
           // empty name when probing graphics cards.
 
           config::video.output_name = display_device::map_display_name(this->display_name);
+
+          // In headless mode, ensure virtual display becomes primary
+          // We need to temporarily override configuration_option to ensure_primary
+          if (config::video.headless_mode) {
+            BOOST_LOG(info) << "Headless mode: Configuring virtual display as primary";
+            
+            // Save original configuration option
+            auto original_config_option = config::video.dd.configuration_option;
+            
+            // Temporarily set to ensure_primary to make virtual display the primary one
+            config::video.dd.configuration_option = config::video_t::dd_t::config_option_e::ensure_primary;
+            
+            // Give Windows time to register the new display
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            
+            // Apply the configuration which will make it primary
+            display_device::configure_display(config::video, *launch_session);
+            
+            // Restore original configuration option
+            config::video.dd.configuration_option = original_config_option;
+            
+            BOOST_LOG(info) << "Headless mode: Virtual display configured as primary";
+          }
         } else {
           BOOST_LOG(warning) << "Virtual Display creation failed, or cannot get created display name in time!";
         }


### PR DESCRIPTION
Fixes issue where applications (like Steam) launch on the physical monitor instead of the virtual display when headless mode is enabled.

Problem
When `headless_mode` is enabled and a virtual display is created, Steam and other applications still launch on the physical monitor because the virtual display is not set as primary.

Solution
- Automatically configure virtual display as primary when `headless_mode` is enabled
- Uses existing `display_device::configure_display()` API with `ensure_primary` flag
- Temporarily overrides `dd.configuration_option` during setup
- Properly manages display topology through SettingsManager instead of direct Win32 calls

Testing
Tested on Windows with NVIDIA RTX 3080 Ti and SudoVDA driver:
- Applications (Steam) now correctly launch on virtual display in headless mode
- Display configuration properly reverts after session endsoach uses the existing SettingsManager API instead of direct Win32 calls for more reliable display management.