### PR TITLE
Send external_ip config property to clients

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -958,6 +958,8 @@ namespace nvhttp {
       tree.put("root.LocalIP", net::addr_to_normalized_string(local_endpoint.address()));
     }
 
+    tree.put("root.ExternalIP", config::nvhttp.external_ip);
+
     uint32_t codec_mode_flags = SCM_H264;
     if (video::last_encoder_probe_supported_yuv444_for_codec[0]) {
       codec_mode_flags |= SCM_H264_HIGH8_444;


### PR DESCRIPTION
### Rationale
There is no mechanism that determines the external IP address of the machine, which is crucial especially for computers behind VPN/NAT. Sending the manually set external IP address to the client, will allow for the machine to be discoverable in local and remote scenarios.
### What Changed
Addition of an additional JSON property `root.ExternalIP` to the Nvidia GameStream's protocol, that reflects the server's config `external_ip` property value.
### Impact
No change in behaviour on the server's side; clients will have one additonal endpoint to check at discovery and to send to for WoL packets.