### PR TITLE
Update device resolution recommendation for Pixel in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Here're some common causes and solutions for stutters: [WiKi](https://github.com
 
 ## Device specific setups
 - Pixel devices might not be able to use native resolution:
-  - Change the device resolution to High: https://github.com/ClassicOldSong/Apollo/issues/700
+  - Change the device resolution to Max: https://github.com/ClassicOldSong/Apollo/issues/700
 
 ## System Requirements
 


### PR DESCRIPTION
Small typo but cause me some confusion until I read the actual issue  https://github.com/ClassicOldSong/Apollo/issues/700. Needs to be set to "Max", not "High". Replicated on my P9 Pro.