### PR TITLE
Add seat abstraction and per-seat video capture

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -87,6 +87,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/confighttp.h"
         "${CMAKE_SOURCE_DIR}/src/rtsp.cpp"
         "${CMAKE_SOURCE_DIR}/src/rtsp.h"
+        "${CMAKE_SOURCE_DIR}/src/seat.cpp"
+        "${CMAKE_SOURCE_DIR}/src/seat.h"
         "${CMAKE_SOURCE_DIR}/src/stream.cpp"
         "${CMAKE_SOURCE_DIR}/src/stream.h"
         "${CMAKE_SOURCE_DIR}/src/video.cpp"

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -1156,12 +1156,21 @@ namespace rtsp_stream {
       return;
     }
 
-    auto stream_session = stream::session::alloc(config, session);
+    // Acquire a seat for this session
+    auto session_seat = seat::manager.acquire();
+    if (!session_seat) {
+      BOOST_LOG(error) << "No available seat for new session"sv;
+      respond(sock, session, &option, 503, "Service Unavailable", req->sequenceNumber, {});
+      return;
+    }
+
+    auto stream_session = stream::session::alloc(config, session, session_seat);
     server->insert(stream_session);
 
     if (stream::session::start(*stream_session, sock.remote_endpoint().address().to_string())) {
       BOOST_LOG(error) << "Failed to start a streaming session"sv;
 
+      seat::manager.release(session_seat);
       server->remove(stream_session);
       respond(sock, session, &option, 500, "Internal Server Error", req->sequenceNumber, {});
       return;

--- a/src/seat.cpp
+++ b/src/seat.cpp
@@ -1,0 +1,91 @@
+/**
+ * @file src/seat.cpp
+ * @brief Implementation of multi-seat management.
+ */
+
+// local includes
+#include "seat.h"
+#include "logging.h"
+
+using namespace std::literals;
+
+namespace seat {
+
+  manager_t manager;
+
+  seat_ptr make_default_seat() {
+    auto seat = std::make_shared<seat_t>();
+    seat->id = "default";
+    // Empty display_name and audio_sink_id cause fallback to global config
+    return seat;
+  }
+
+  seat_ptr manager_t::acquire() {
+    std::lock_guard lg(_mutex);
+
+    if (!_multi_seat) {
+      // Single-seat mode: always return the same default seat
+      if (!_default_seat) {
+        _default_seat = make_default_seat();
+      }
+
+      _default_seat->state = state_e::BOUND;
+
+      BOOST_LOG(info) << "Seat acquired: "sv << _default_seat->id;
+      return _default_seat;
+    }
+
+    // Multi-seat mode: find an available seat or create one
+    for (auto &s : _seats) {
+      if (s->state == state_e::AVAILABLE) {
+        s->state = state_e::BOUND;
+        BOOST_LOG(info) << "Seat acquired: "sv << s->id;
+        return s;
+      }
+    }
+
+    // TODO (Phase 5+): Create a new seat with virtual display
+    BOOST_LOG(warning) << "No available seats"sv;
+    return nullptr;
+  }
+
+  void manager_t::release(const seat_ptr &seat) {
+    if (!seat) return;
+
+    std::lock_guard lg(_mutex);
+
+    BOOST_LOG(info) << "Seat released: "sv << seat->id;
+
+    seat->state = state_e::AVAILABLE;
+    seat->bound_session.reset();
+
+    // In single-seat mode, keep the default seat around for reuse.
+    // In multi-seat mode (future), we may tear down virtual displays here.
+  }
+
+  std::vector<seat_ptr> manager_t::active_seats() const {
+    std::lock_guard lg(_mutex);
+
+    std::vector<seat_ptr> result;
+
+    if (!_multi_seat) {
+      if (_default_seat && _default_seat->state == state_e::BOUND) {
+        result.push_back(_default_seat);
+      }
+      return result;
+    }
+
+    for (const auto &s : _seats) {
+      if (s->state == state_e::BOUND) {
+        result.push_back(s);
+      }
+    }
+    return result;
+  }
+
+  bool manager_t::multi_seat_enabled() const {
+    std::lock_guard lg(_mutex);
+    return _multi_seat;
+  }
+
+}  // namespace seat

--- a/src/seat.h
+++ b/src/seat.h
@@ -1,0 +1,114 @@
+/**
+ * @file src/seat.h
+ * @brief Declarations for multi-seat management.
+ *
+ * A "seat" is a bundle of desktop resources (display, audio endpoint, input target)
+ * assigned to one streaming session. In single-seat mode (default), a single default
+ * seat transparently wraps the existing global configuration. In multi-seat mode,
+ * each concurrent session gets its own isolated seat with dedicated resources.
+ */
+#pragma once
+
+// standard includes
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+  #include <guiddef.h>
+#endif
+
+namespace seat {
+
+  enum class state_e {
+    AVAILABLE,   ///< Seat resources are allocated but not bound to a session
+    BOUND,       ///< Seat is actively streaming
+    RELEASING,   ///< Seat is being torn down
+  };
+
+  /**
+   * @brief Represents an input routing target for a seat.
+   */
+  struct input_target_t {
+    std::string display_name;  ///< For SendInput targeting (Windows)
+  };
+
+  /**
+   * @brief A bundle of desktop resources assigned to one streaming session.
+   */
+  struct seat_t {
+    std::string id;                    ///< Unique seat identifier
+    std::string display_name;          ///< Video capture target (empty = use config default)
+    std::string audio_sink_id;         ///< Audio capture target (empty = system default)
+    input_target_t input_target;
+
+#ifdef _WIN32
+    std::optional<GUID> vdisplay_guid; ///< Virtual display GUID (Windows)
+#endif
+
+    state_e state = state_e::AVAILABLE;
+
+    /**
+     * @brief The session currently bound to this seat.
+     * Weak pointer to avoid circular references with session_t.
+     */
+    std::weak_ptr<void> bound_session;
+  };
+
+  using seat_ptr = std::shared_ptr<seat_t>;
+
+  /**
+   * @brief Creates a default seat that mirrors current single-user behavior.
+   *
+   * The default seat uses empty display_name and audio_sink_id, which causes
+   * all subsystems to fall back to their existing global configuration.
+   */
+  seat_ptr make_default_seat();
+
+  /**
+   * @brief Manages seat allocation, tracking, and release.
+   *
+   * In single-seat mode, acquire() always returns the same default seat.
+   * In multi-seat mode, it allocates from a pool or creates new virtual displays.
+   */
+  class manager_t {
+  public:
+    /**
+     * @brief Acquire a seat for a new session.
+     * @return A seat pointer, or nullptr if no seat is available.
+     */
+    seat_ptr acquire();
+
+    /**
+     * @brief Release a seat when a session ends.
+     * @param seat The seat to release.
+     */
+    void release(const seat_ptr &seat);
+
+    /**
+     * @brief Get all active (non-available) seats.
+     * @return Vector of seat pointers.
+     */
+    std::vector<seat_ptr> active_seats() const;
+
+    /**
+     * @brief Check if multi-seating is enabled.
+     * @return true if multi-seat mode is active.
+     */
+    bool multi_seat_enabled() const;
+
+  private:
+    mutable std::mutex _mutex;
+    std::vector<seat_ptr> _seats;
+    seat_ptr _default_seat;  ///< Singleton seat for single-seat mode
+    bool _multi_seat = false;  ///< Driven by config (future Phase 8)
+  };
+
+  /**
+   * @brief Global seat manager instance.
+   */
+  extern manager_t manager;
+
+}  // namespace seat

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -411,6 +411,8 @@ namespace stream {
       safe::mail_raw_t::event_t<video::hdr_info_t> hdr_queue;
     } control;
 
+    seat::seat_ptr seat;
+
     std::uint32_t launch_session_id;
     std::string device_name;
     std::string device_uuid;
@@ -1917,7 +1919,12 @@ namespace stream {
     session->video.qos = platf::enable_socket_qos(ref->video_sock.native_handle(), address, session->video.peer.port(), platf::qos_data_type_e::video, session->config.videoQosType != 0);
 
     BOOST_LOG(debug) << "Start capturing Video"sv;
-    video::capture(session->mail, session->config.monitor, session);
+    video::capture(
+      session->mail,
+      session->config.monitor,
+      session,
+      session->seat ? session->seat->display_name : ""
+    );
   }
 
   void audioThread(session_t *session) {
@@ -2083,6 +2090,11 @@ namespace stream {
         platf::streaming_will_stop();
       }
 
+      // Release the seat back to the seat manager
+      if (session.seat) {
+        seat::manager.release(session.seat);
+      }
+
       BOOST_LOG(debug) << "Session ended"sv;
     }
 
@@ -2145,8 +2157,11 @@ namespace stream {
       return 0;
     }
 
-    std::shared_ptr<session_t> alloc(config_t &config, rtsp_stream::launch_session_t &launch_session) {
+    std::shared_ptr<session_t> alloc(config_t &config, rtsp_stream::launch_session_t &launch_session, const seat::seat_ptr &seat) {
       auto session = std::make_shared<session_t>();
+
+      // Assign the seat to this session (may be nullptr in single-seat mode without explicit acquisition)
+      session->seat = seat;
 
       auto mail = std::make_shared<safe::mail_raw_t>();
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -13,6 +13,7 @@
 // local includes
 #include "audio.h"
 #include "crypto.h"
+#include "seat.h"
 #include "video.h"
 
 namespace stream {
@@ -46,7 +47,7 @@ namespace stream {
       RUNNING,  ///< The session is running
     };
 
-    std::shared_ptr<session_t> alloc(config_t &config, rtsp_stream::launch_session_t &launch_session);
+    std::shared_ptr<session_t> alloc(config_t &config, rtsp_stream::launch_session_t &launch_session, const seat::seat_ptr &seat = nullptr);
     std::string uuid(const session_t& session);
     bool uuid_match(const session_t& session, const std::string_view& uuid);
     bool update_device_info(session_t& session, const std::string& name, const crypto::PERM& newPerm);

--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -457,7 +457,7 @@ namespace safe {
 
     std::array<std::uint8_t, sizeof(element_type)> _object_buf;
 
-    std::uint32_t _count;
+    std::uint32_t _count = 0;
     std::mutex _lock;
   };
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -7,6 +7,7 @@
 #include <bitset>
 #include <list>
 #include <thread>
+#include <unordered_map>
 
 // lib includes
 #include <boost/pointer_cast.hpp>
@@ -468,6 +469,8 @@ namespace video {
     safe::signal_t reinit_event;
     const encoder_t *encoder_p;
     sync_util::sync_t<std::weak_ptr<platf::display_t>> display_wp;
+
+    std::string display_name;  ///< Per-seat display target (empty = use config default)
   };
 
   struct capture_thread_sync_ctx_t {
@@ -479,8 +482,47 @@ namespace video {
   int start_capture_async(capture_thread_async_ctx_t &ctx);
   void end_capture_async(capture_thread_async_ctx_t &ctx);
 
-  // Keep a reference counter to ensure the capture thread only runs when other threads have a reference to the capture thread
-  auto capture_thread_async = safe::make_shared<capture_thread_async_ctx_t>(start_capture_async, end_capture_async);
+  // Per-display async capture thread pool.
+  // Each unique display target gets its own capture thread, keyed by display name.
+  // The existing safe::shared_t lifecycle pattern is preserved: the capture thread
+  // starts when the first session references it and stops when the last session drops.
+  static std::mutex capture_threads_mutex;
+  static std::unordered_map<std::string, std::unique_ptr<safe::shared_t<capture_thread_async_ctx_t>>> capture_threads;
+
+  /**
+   * @brief Get or create an async capture thread for the given display target.
+   * @param display_name The display to capture from (empty = config default).
+   * @return Reference to the shared_t managing the capture thread lifecycle.
+   */
+  static safe::shared_t<capture_thread_async_ctx_t> &
+  get_capture_thread_for_display(const std::string &display_name) {
+    std::lock_guard lock(capture_threads_mutex);
+
+    auto key = display_name.empty() ? std::string("__default__") : display_name;
+    auto it = capture_threads.find(key);
+    if (it != capture_threads.end()) {
+      return *it->second;
+    }
+
+    // Create a new capture thread container for this display.
+    // The lambda captures the display_name and stores it in the context
+    // before starting the capture thread.
+    auto dn = display_name;  // copy for lambda capture
+    auto ptr = std::unique_ptr<safe::shared_t<capture_thread_async_ctx_t>>(
+      new safe::shared_t<capture_thread_async_ctx_t>(
+        [dn](capture_thread_async_ctx_t &ctx) -> int {
+          ctx.display_name = dn;
+          return start_capture_async(ctx);
+        },
+        end_capture_async
+      )
+    );
+
+    auto [inserted_it, _] = capture_threads.emplace(key, std::move(ptr));
+    return *inserted_it->second;
+  }
+
+  // Keep a reference counter to ensure the sync capture thread only runs when other threads have a reference
   auto capture_thread_sync = safe::make_shared<capture_thread_sync_ctx_t>(start_capture_sync, end_capture_sync);
 
 #ifdef _WIN32
@@ -1081,10 +1123,16 @@ namespace video {
    * @param dev_type The encoder device type used for display lookup.
    * @param display_names The list of display names to repopulate.
    * @param current_display_index The current display index or -1 if not yet known.
+   * @param preferred_display_name Name of a previously active display to try to stay on.
+   * @param output_name_override Per-seat display target override. When non-empty, replaces
+   *   config::video.output_name as the fallback display for this capture thread.
    */
-  void refresh_displays(platf::mem_type_e dev_type, std::vector<std::string> &display_names, int &current_display_index, std::string &preferred_display_name) {
-    // It is possible that the output name may be empty even if it wasn't before (device disconnected) or vice-versa
-    const auto output_name { display_device::map_output_name(config::video.output_name) };
+  void refresh_displays(platf::mem_type_e dev_type, std::vector<std::string> &display_names, int &current_display_index,
+    std::string &preferred_display_name, const std::string &output_name_override = "") {
+    // Use the per-seat display target if provided, otherwise fall back to the global config
+    const auto output_name { display_device::map_output_name(
+      output_name_override.empty() ? config::video.output_name : output_name_override
+    ) };
     std::string current_display_name = preferred_display_name;
 
     // If we have a current display index, let's start with that
@@ -1109,7 +1157,9 @@ namespace video {
     current_display_index = 0;
 
     if (current_display_name.empty()) {
-      current_display_name = display_device::map_output_name(config::video.output_name);
+      current_display_name = display_device::map_output_name(
+        output_name_override.empty() ? config::video.output_name : output_name_override
+      );
     }
 
     // If we had a name previously, let's try to find it in the new list
@@ -1142,7 +1192,8 @@ namespace video {
     std::shared_ptr<safe::queue_t<capture_ctx_t>> capture_ctx_queue,
     sync_util::sync_t<std::weak_ptr<platf::display_t>> &display_wp,
     safe::signal_t &reinit_event,
-    const encoder_t &encoder
+    const encoder_t &encoder,
+    const std::string &seat_display_name  ///< Per-seat display target (empty = use config default)
   ) {
     std::vector<capture_ctx_t> capture_ctxs;
 
@@ -1167,19 +1218,27 @@ namespace video {
     }
     capture_ctxs.emplace_back(std::move(*initial_capture_ctx));
 
+    // Use per-seat display target if provided, otherwise fall back to proc display name
+    const auto &initial_display = seat_display_name.empty() ? proc::proc.display_name : seat_display_name;
+    // Tracks the preferred display for this capture thread across reinits
+    std::string preferred_display;
+
     std::vector<std::string> display_names;
     int display_p = -1;
     std::shared_ptr<platf::display_t> disp;
-    if (!proc::proc.display_name.empty()) {
-      disp = platf::display(encoder.platform_formats->dev_type, proc::proc.display_name, capture_ctxs.front().config);
+    if (!initial_display.empty()) {
+      disp = platf::display(encoder.platform_formats->dev_type, initial_display, capture_ctxs.front().config);
     }
     if (!disp) {
       // Get all the monitor names now, rather than at boot, to
       // get the most up-to-date list available monitors
-      refresh_displays(encoder.platform_formats->dev_type, display_names, display_p);
+      refresh_displays(encoder.platform_formats->dev_type, display_names, display_p, preferred_display, seat_display_name);
       disp = platf::display(encoder.platform_formats->dev_type, display_names[display_p], capture_ctxs.front().config);
       if (disp) {
-        proc::proc.display_name = display_names[display_p];
+        // Only update the global proc display name in single-seat mode (empty seat_display_name)
+        if (seat_display_name.empty()) {
+          proc::proc.display_name = display_names[display_p];
+        }
       } else {
         return;
       }
@@ -1368,8 +1427,11 @@ namespace video {
               // only support a single display session per device/application.
               disp.reset();
 
+              // Use per-seat display as preferred, falling back to proc display name in single-seat mode
+              auto &reinit_preferred = seat_display_name.empty() ? proc::proc.display_name : preferred_display;
+
               // Refresh display names since a display removal might have caused the reinitialization
-              refresh_displays(encoder.platform_formats->dev_type, display_names, display_p, proc::proc.display_name);
+              refresh_displays(encoder.platform_formats->dev_type, display_names, display_p, reinit_preferred, seat_display_name);
 
               // Process any pending display switch with the new list of displays
               if (switch_display_event->peek()) {
@@ -1379,7 +1441,11 @@ namespace video {
               // reset_display() will sleep between retries
               reset_display(disp, encoder.platform_formats->dev_type, display_names[display_p], capture_ctxs.front().config);
               if (disp) {
-                proc::proc.display_name = display_names[display_p];
+                // Only update the global proc display name in single-seat mode
+                if (seat_display_name.empty()) {
+                  proc::proc.display_name = display_names[display_p];
+                }
+                preferred_display = display_names[display_p];
                 break;
               }
             }
@@ -2354,7 +2420,8 @@ namespace video {
   void capture_async(
     safe::mail_t mail,
     config_t &config,
-    void *channel_data
+    void *channel_data,
+    const std::string &display_name = ""
   ) {
     auto shutdown_event = mail->event<bool>(mail::shutdown);
 
@@ -2364,7 +2431,7 @@ namespace video {
       shutdown_event->raise(true);
     });
 
-    auto ref = capture_thread_async.ref();
+    auto ref = get_capture_thread_for_display(display_name).ref();
     if (!ref) {
       return;
     }
@@ -2438,13 +2505,14 @@ namespace video {
   void capture(
     safe::mail_t mail,
     config_t config,
-    void *channel_data
+    void *channel_data,
+    const std::string &display_name
   ) {
     auto idr_events = mail->event<bool>(mail::idr);
 
     idr_events->raise(true);
     if (chosen_encoder->flags & PARALLEL_ENCODING) {
-      capture_async(std::move(mail), config, channel_data);
+      capture_async(std::move(mail), config, channel_data, display_name);
     } else {
       safe::signal_t join_event;
       auto ref = capture_thread_sync.ref();
@@ -2990,7 +3058,8 @@ namespace video {
       capture_thread_ctx.capture_ctx_queue,
       std::ref(capture_thread_ctx.display_wp),
       std::ref(capture_thread_ctx.reinit_event),
-      std::ref(*capture_thread_ctx.encoder_p)
+      std::ref(*capture_thread_ctx.encoder_p),
+      capture_thread_ctx.display_name  // Per-seat display target
     };
 
     return 0;

--- a/src/video.h
+++ b/src/video.h
@@ -344,7 +344,8 @@ namespace video {
   void capture(
     safe::mail_t mail,
     config_t config,
-    void *channel_data
+    void *channel_data,
+    const std::string &display_name = ""  ///< Per-seat display target (empty = use config default)
   );
 
   bool validate_encoder(encoder_t &encoder, bool expect_failure);


### PR DESCRIPTION
## Summary
- **Phase 1 - Seat Abstraction Layer**: Introduces `seat_t` struct bundling display, audio, and input resources per session. `seat::manager` handles thread-safe acquire/release. Integrated into RTSP session setup and stream lifecycle.
- **Phase 2 - Per-Seat Video Capture**: Replaces global `capture_thread_async` with a per-display capture thread map. Each seat can target its own display independently. Fully backward-compatible in single-seat mode.
- Fixes uninitialized `_count` in `safe::shared_t` for heap-allocated instances.

## Test plan
- [ ] Verify single-seat streaming still works identically (backward compatibility)
- [ ] Confirm seat is acquired on RTSP ANNOUNCE and released on session end
- [ ] Test that session start failure properly releases the seat
- [ ] Verify capture thread is created per unique display name
- [ ] Check that `proc::proc.display_name` is only updated in single-seat mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)