### PR TITLE
fix(wayland): set frame timestamps for wlgrab captures

### DIFF
--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -174,6 +174,7 @@ namespace wl {
       if (status != platf::capture_e::ok) {
         return status;
       }
+      auto frame_timestamp = std::chrono::steady_clock::now();
 
       auto current_frame = dmabuf.current_frame;
 
@@ -197,6 +198,7 @@ namespace wl {
 
       gl::ctx.GetTextureSubImage((*rgb_opt)->tex[0], 0, 0, 0, 0, width, height, 1, GL_BGRA, GL_UNSIGNED_BYTE, img_out->height * img_out->row_pitch, img_out->data);
       gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
+      img_out->frame_timestamp = frame_timestamp;
 
       return platf::capture_e::ok;
     }
@@ -304,6 +306,7 @@ namespace wl {
       if (status != platf::capture_e::ok) {
         return status;
       }
+      auto frame_timestamp = std::chrono::steady_clock::now();
 
       if (!pull_free_image_cb(img_out)) {
         return platf::capture_e::interrupted;
@@ -317,6 +320,7 @@ namespace wl {
       img->sequence = sequence;
 
       img->sd = current_frame->sd;
+      img->frame_timestamp = frame_timestamp;
 
       // Prevent dmabuf from closing the file descriptors.
       std::fill_n(current_frame->sd.fds, 4, -1);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1977,6 +1977,7 @@ namespace video {
     }
 
     std::chrono::steady_clock::time_point encode_frame_timestamp;
+    bool missing_frame_timestamp_warning_logged = false;
 
     while (true) {
       // Break out of the encoding loop if any of the following are true:
@@ -2014,6 +2015,10 @@ namespace video {
         if (auto img = images->pop(max_frametime)) {
           frame_timestamp = img->frame_timestamp;
           if (!frame_timestamp) {
+            if (!missing_frame_timestamp_warning_logged) {
+              BOOST_LOG(warning) << "Encoder received image without frame timestamp; substituting steady_clock::now()"sv;
+              missing_frame_timestamp_warning_logged = true;
+            }
             frame_timestamp = std::chrono::steady_clock::now();
           }
 


### PR DESCRIPTION
## Summary

Wayland wlgrab frames were reaching the encoder without `frame_timestamp` populated.

The encode loop in `video.cpp` assumes captured images have a timestamp and uses it for frame pacing. On systems with `_GLIBCXX_ASSERTIONS`, this can trip the `std::optional` assertion when dereferencing an empty timestamp. 
Without assertions, it can degrade into undefined behavior and stale/frozen video output.

This change:
- sets `frame_timestamp` for wlgrab RAM captures
- sets `frame_timestamp` for wlgrab VRAM captures
- adds a small defensive fallback in the encoder if a backend ever still submits a frame without a timestamp

## Why

On Wayland virtual-output streaming, Apollo was capturing the first frame and then effectively stalling/failing in the
  encoder path because the Wayland capture backend never stamped frames with capture time.

The other Linux backends already populate frame timestamps, so this brings wlgrab in line with existing behavior.

## Testing

Manually tested on Linux/Wayland (Hyprland) with a virtual display output:
- before: first frame displayed, then video froze while audio/input continued
- after: live video updates stream correctly

Also rebuilt Apollo locally and verified streaming remained stable through repeated session startup/shutdown.
