### PR TITLE
fix(vaapi): enable rate control buffer and explicit rc_mode for VAAPI encoders

### DIFF
--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -287,7 +287,16 @@ namespace va {
         BOOST_LOG(warning) << "Using CQP rate control"sv;
         av_dict_set_int(options, "qp", config::video.qp, 0);
       } else {
-        BOOST_LOG(info) << "Using default rate control"sv;
+        // For remaining VAAPI encoders (typically AMD H.264/HEVC), explicitly
+        // select a rate control mode. The VBV buffer size is already set by
+        // the common encoder code in video.cpp.
+        if (rc_attr.value & VA_RC_CBR) {
+          BOOST_LOG(info) << "Using CBR rate control"sv;
+          av_dict_set(options, "rc_mode", "CBR", 0);
+        } else if (rc_attr.value & VA_RC_VBR) {
+          BOOST_LOG(info) << "Using VBR rate control"sv;
+          av_dict_set(options, "rc_mode", "VBR", 0);
+        }
       }
     }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -961,8 +961,7 @@ namespace video {
       {},  // Fallback options
       "h264_vaapi"s,
     },
-    // RC buffer size will be set in platform code if supported
-    LIMITED_GOP_SIZE | PARALLEL_ENCODING | NO_RC_BUF_LIMIT
+    PARALLEL_ENCODING
   };
 #endif
 


### PR DESCRIPTION
## Problem

4K HEVC streaming on AMD GPUs via VAAPI produces unconstrained frame sizes during scene changes. The first I-frame after a scene transition (e.g. loading screen → gameplay) can be 5-10x larger than the average frame, exceeding the Moonlight protocol's FEC limit (~800KB with default settings). When this happens, FEC is skipped for those frames, the client receives corrupted data, and the stream either shows decode errors or disconnects entirely.

## Root cause

The VAAPI encoder definition has `NO_RC_BUF_LIMIT`, which prevents `video.cpp` from setting `rc_buffer_size`. The intent was for platform code (`vaapi.cpp`) to set it, but the AMD H.264/HEVC path never did — it logged `"Using default rate control"` and set nothing. No `rc_mode`, no `rc_buffer_size`.

Without `rc_buffer_size`, frame size spikes are expected encoder behavior — confirmed by Mesa developer David Rosca (https://gitlab.freedesktop.org/mesa/mesa/-/issues/15160#note_2873498). This is not GPU-generation-specific; it affects all AMD VAAPI encoders.

The `LIMITED_GOP_SIZE` flag is also unnecessary — VAAPI encoders handle large GOP values correctly.

## Fix

- **Remove `NO_RC_BUF_LIMIT`** from the VAAPI encoder definition so the common code in `video.cpp` sets `rc_buffer_size = bitrate / framerate` (single-frame VBV), consistent with all other hardware encoders.
- **Remove `LIMITED_GOP_SIZE`** as it is no longer needed for VAAPI.
- **Explicitly set `rc_mode`** to CBR (preferred) or VBR for AMD H.264/HEVC in `vaapi.cpp`, rather than leaving it to auto-selection.

This is a minimal change: flag removal in `video.cpp` lets existing infrastructure handle VBV sizing, while `vaapi.cpp` retains platform-specific rate control mode selection.

## Impact

- **AMD H.264/HEVC**: Now gets `rc_buffer_size` (from `video.cpp`) and explicit `rc_mode` (from `vaapi.cpp`). This is the fix.
- **Intel / AV1 / `strict_rc_buffer`**: Already set their own `rc_buffer_size` and `rc_mode` in `vaapi.cpp`. The `video.cpp` value is harmlessly overridden. No behavior change.
- **CQP fallback**: `rc_buffer_size` is now set by `video.cpp` (previously unset). Harmless — CQP ignores rate control buffers.

## Validation

**Live streaming test** on RX 9070 XT (gfx1201, Mesa 26.0.3): 4K60 HEVC session with zero FEC overflows. Before this fix, FEC overflows occurred within seconds of connecting.

**ffmpeg frame size comparison** (4K60 HEVC, 25Mbps, scene change):

| Mode | Max frame size |
|------|---------------|
| No rc_buffer_size (before) | 400,792 bytes |
| Single-frame VBV (after) | 235,160 bytes |

## Hardware tested

- AMD Radeon RX 9070 XT (Navi 48 / gfx1201)
- Mesa 26.0.3, libva 2.23.0, kernel 6.18.19