### PR TITLE
fix(video): enabled profile and coder options for AMD AMF encoder

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -821,9 +821,17 @@ namespace video {
         {"rc"s, &config::video.amd.amd_rc_h264},
         {"usage"s, &config::video.amd.amd_usage_h264},
         {"vbaq"s, &config::video.amd.amd_vbaq},
+        {"coder"s, &config::video.amd.amd_coder},
         {"enforce_hrd"s, &config::video.amd.amd_enforce_hrd},
       },
-      {},  // SDR-specific options
+      {
+        // SDR-specific options
+        {"profile"s, [](const config_t &cfg) {
+           if (cfg.profile == 66) return "baseline"s;
+           if (cfg.profile == 77) return "main"s;
+           return "high"s;
+         }},
+      },
       {},  // HDR-specific options
       {},  // YUV444 SDR-specific options
       {},  // YUV444 HDR-specific options


### PR DESCRIPTION
### Description
Currently, the AMD AMF encoder (`h264_amf`) in `src/video.cpp` does not have the `profile` and `coder` options wired up in its `encoder_t` definition. This prevents clients that strictly require H.264 Baseline/CAVLC (like the Sony PSP or other legacy hardware decoders) from successfully streaming, as the encoder defaults to High Profile and CABAC regardless of the client's request or the global configuration.

### Why this is needed
Older hardware decoders often have hardwired limitations. For example, the PSP-1000's Media Engine only supports:
- H.264 Baseline Profile (not Main or High)
- CAVLC entropy coding (not CABAC)

While Sunshine/Apollo allows selecting `cavlc` in the UI, this setting is ignored by the `h264_amf` encoder because it isn't passed to the FFmpeg `avcodec_open2` dictionary.

### Proposed Fix
Update the `amdvce` definition in `src/video.cpp` to include the missing options:

```cpp
        {"coder"s, &config::video.amd.amd_coder},
        {"profile"s, [](const config_t &cfg) {
           if (cfg.profile == 66) return "baseline"s;
           if (cfg.profile == 77) return "main"s;
           return "high"s;
         }},
```

This brings the AMD implementation into parity with NVENC and QuickSync.
