### PR TITLE
feature(audio): release audio sink on client pause

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -308,18 +308,40 @@ namespace audio {
     return 0;
   }
 
+  static void revert_audio_sink(audio_ctx_t &ctx) {
+    // Change back to the host sink, unless there was none
+    const std::string &sink = ctx.sink.host.empty() ? config::audio.sink : ctx.sink.host;
+    if (!sink.empty()) {
+      BOOST_LOG(info) << "Restoring audio sink to: "sv << sink;
+      // Best effort, it's allowed to fail
+      ctx.control->set_sink(sink);
+    }
+  }
+
   void stop_audio_control(audio_ctx_t &ctx) {
     // restore audio-sink if applicable
     if (!ctx.restore_sink) {
       return;
     }
 
-    // Change back to the host sink, unless there was none
-    const std::string &sink = ctx.sink.host.empty() ? config::audio.sink : ctx.sink.host;
-    if (!sink.empty()) {
-      // Best effort, it's allowed to fail
-      ctx.control->set_sink(sink);
+    revert_audio_sink(ctx);
+  }
+
+  void restore_sink() {
+    auto ref = get_audio_ctx_ref();
+    if (!ref) {
+      return;
     }
+
+    auto *ctx = ref.get();
+    if (!ctx->control || !ctx->restore_sink) {
+      return;
+    }
+
+    revert_audio_sink(*ctx);
+
+    ctx->restore_sink = false;
+    ctx->sink_flag->store(false, std::memory_order_release);
   }
 
   void apply_surround_params(opus_stream_config_t &stream, const stream_params_t &params) {

--- a/src/audio.h
+++ b/src/audio.h
@@ -106,4 +106,6 @@ namespace audio {
    * @examples_end
    */
   bool is_audio_ctx_sink_available(const audio_ctx_t &ctx);
+
+  void restore_sink();
 }  // namespace audio

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -525,6 +525,7 @@ namespace config {
     true,  // install_steam_drivers
     true, // keep_sink_default
     true, // auto_capture
+    false, // release_sink_on_pause
   };
 
   stream_t stream {
@@ -1231,6 +1232,7 @@ namespace config {
     bool_f(vars, "install_steam_audio_drivers", audio.install_steam_drivers);
     bool_f(vars, "keep_sink_default", audio.keep_default);
     bool_f(vars, "auto_capture_sink", audio.auto_capture);
+    bool_f(vars, "release_sink_on_pause", audio.release_sink_on_pause);
 
     string_restricted_f(vars, "origin_web_ui_allowed", nvhttp.origin_web_ui_allowed, {"pc"sv, "lan"sv, "wan"sv});
 

--- a/src/config.h
+++ b/src/config.h
@@ -158,6 +158,7 @@ namespace config {
     bool install_steam_drivers;
     bool keep_default;
     bool auto_capture;
+    bool release_sink_on_pause;
   };
 
   constexpr int ENCRYPTION_MODE_NEVER = 0;  // Never use video encryption, even if the client supports it

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -20,6 +20,7 @@ extern "C" {
 }
 
 // local includes
+#include "audio.h"
 #include "config.h"
 #include "crypto.h"
 #include "display_device.h"
@@ -2071,6 +2072,9 @@ namespace stream {
         bool revert_display_config {config::video.dd.config_revert_on_disconnect};
         if (proc::proc.running()) {
           proc::proc.pause();
+          if (config::audio.release_sink_on_pause) {
+            audio::restore_sink();
+          }
         } else {
           // We have no app running and also no clients anymore.
           revert_display_config = true;

--- a/src_assets/common/assets/web/config.html
+++ b/src_assets/common/assets/web/config.html
@@ -192,6 +192,7 @@
               "install_steam_audio_drivers": "enabled",
               "keep_sink_default": "enabled",
               "auto_capture_sink": "enabled",
+              "release_sink_on_pause": "disabled",
               "stream_audio": "enabled",
               "adapter_name": "",
               "output_name": "",

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -97,6 +97,13 @@ const validateFallbackMode = (event) => {
                   v-model="config.auto_capture_sink"
                   default="true"
         ></Checkbox>
+
+        <Checkbox class="mb-3"
+                  id="release_sink_on_pause"
+                  locale-prefix="config"
+                  v-model="config.release_sink_on_pause"
+                  default="false"
+        ></Checkbox>
       </template>
     </PlatformLayout>
 

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -417,6 +417,8 @@
     "qsv_preset_veryfast": "fastest (lowest quality)",
     "qsv_slow_hevc": "Allow Slow HEVC Encoding",
     "qsv_slow_hevc_desc": "This can enable HEVC encoding on older Intel GPUs, at the cost of higher GPU usage and worse performance.",
+    "release_sink_on_pause": "Release audio sink when paused",
+    "release_sink_on_pause_desc": "When enabled, Apollo will restore the original audio output device when all clients disconnect while a launched app is still running on the host. The virtual sink is re-applied automatically when a new client connects.",
     "restart_note": "Apollo is restarting to apply changes.",
     "server_cmd": "Server Commands",
     "server_cmd_desc": "Configure a list of commands to be executed when called from client during streaming.",


### PR DESCRIPTION
I was going crazy trying to figure out why the PC refused to sleep ([thread](https://gist.github.com/ClassicOldSong/0a088d2a92a06f86e48fe328b67ec995?permalink_comment_id=5930788#gistcomment-5930788)) while using your AHK sleep scripts and realized it's one of 2 things:
- game full screen prevents sleep. (obviously, but irrelevant to this PR)
- audio sink holds audio driver hostage on disconnect (directly relates to this PR)

This change introduces a fix for the second bullet point. It releases the audio driver when all clients disconnect, so it no longer prevents the PC from sleeping.
I've tested these changes on my local machine for over a week now using my own personal [AHK script](https://gist.github.com/RJNY/a1eaf1ca640ae654401f3995221f5a5a) (still needs work) that freezes and minimizes the game, allowing the host PC to sleep on disconnect!

Trying not to go too deep into the AHK script specifics on this audio sink PR, but thought it was relevant to understanding _**why**_ I want this change.

This is an opt-in feature. original behavior is preserved by default. 