### PR TITLE
fix(nvhttp): use-after-free in clientpairingsecret crashes pair flow

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -636,15 +636,21 @@ namespace nvhttp {
       named_cert_p->allow_client_commands = true;
       named_cert_p->always_use_virtual_display = false;
 
-      auto it = map_id_sess.find(client.uniqueID);
-      map_id_sess.erase(it);
-
       add_authorized_client(named_cert_p);
     } else {
       tree.put("root.paired", 0);
       BOOST_LOG(warning) << "Pair attempt failed due to same_hash: " << same_hash << ", verify: " << verify;
     }
 
+    // The previous code performed an eager erase of the session from
+    // map_id_sess on the success branch (before add_authorized_client) and
+    // then called remove_session(sess) below, leaving `sess` (a reference into
+    // the destroyed map slot) dangling. add_authorized_client() invokes
+    // save_state()/load_state(), which allocate heavily and reuse the freed
+    // pair_session_t storage; remove_session() then dereferences
+    // sess.client.uniqueID against corrupted memory, producing a
+    // deterministic 0xc0000005 access violation right after a successful
+    // pair handshake. Single erase via remove_session(sess) is sufficient.
     remove_session(sess);
     tree.put("root.<xmlattr>.status_code", 200);
   }


### PR DESCRIPTION
## Summary

`clientpairingsecret()` in `src/nvhttp.cpp` had a use-after-free in its success path that crashes Apollo with a deterministic 0xc0000005 access violation right after a successful pair handshake. The state file gets written with the new `named_devices` entry, then `Sunshine.exe` faults, and the client sees the connection drop and reports **"pairing failed"** even though the host actually paired.

This appears to be the root cause of [#1436](https://github.com/ClassicOldSong/Apollo/issues/1436) and likely contributes to other reports of clients pairing repeatedly without ever succeeding (especially on iOS Moonlight, where I hit it 100% reproducibly with `Darwin/25.5.0` over LAN against both v0.4.6 and current master `dd99a822`).

## Root cause

`map_id_sess` is `std::unordered_map<std::string, pair_session_t>` — values, not pointers. The success branch did:

```cpp
auto it = map_id_sess.find(client.uniqueID);
map_id_sess.erase(it);                 // destroys the pair_session_t
add_authorized_client(named_cert_p);   // save_state() + load_state() — heavy alloc, reuses freed slot
…
remove_session(sess);                  // sess.client.uniqueID -> corrupted memory -> 0xc0000005
```

`add_authorized_client()` runs `save_state()` (writes `sunshine_state.json`) and `load_state()` (reparses it, rebuilds `client_root.named_devices`, recreates the cert chain). That heap activity reliably reuses the freed `pair_session_t` slot, so the `remove_session(sess)` below dereferences a dangling reference. The crash is at the same offset every run because the allocator reuses the slot the same way.

The hash-mismatch branch never had this problem — it only calls `remove_session(sess)` once.

## Fix

Drop the eager erase. `remove_session(sess)` at the end already handles both branches, and `sess` is still valid at that point because nothing in between mutates `map_id_sess`.

```diff
-      auto it = map_id_sess.find(client.uniqueID);
-      map_id_sess.erase(it);
-
       add_authorized_client(named_cert_p);
     } else {
       tree.put("root.paired", 0);
       BOOST_LOG(warning) << "Pair attempt failed due to same_hash: " << same_hash << ", verify: " << verify;
     }
 
+    // (extended comment in the diff explaining the prior UAF)
     remove_session(sess);
```

Net: +9 / -3 lines including the explanatory comment.

## Test plan

- [x] Reproduced the crash on master `dd99a822` with iOS Moonlight (`Darwin/25.5.0`) on LAN — Application Error 0xc0000005 at fixed offset right after the `/pair?phrase=clientpairingsecret` request, `sunshine_state.json` already updated with the new device.
- [x] Same repro on v0.4.6 release (different binary offset, same call stack).
- [x] After this patch: pair completes cleanly, no application errors, client transitions to paired state, streaming works.
- [x] Hash-mismatch path still cleans up the session (verified by injecting a wrong PIN — `remove_session(sess)` is hit once, no leak).
- [x] No new warnings under `-Wall -Wextra` (gcc 16, ucrt64).

## Notes for reviewers

While auditing this path I noticed two adjacent issues that I'm happy to send as separate PRs if you're interested:

1. `map_id_sess` and `client_root` are mutated from multiple threads (HTTPS pair handler, HTTP pair handler, web-UI `pin()` thread) with no lock. The same UAF class is reachable concurrently — two simultaneous pair attempts can race the destructor.
2. `nvhttp::pin()` uses `std::begin(map_id_sess)->second` to pick a session, which doesn't correlate the user-typed PIN with the specific pending device. With two concurrent pair attempts the wrong device can be paired with the legitimate user's PIN.

Both are pre-existing but worth fixing while pair-flow ownership is in mind. Happy to file follow-ups.