### PR TITLE
docs(building): drop MSYS2 nodejs from Windows deps to avoid gcc-16 bad_weak_ptr

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -102,7 +102,6 @@ dependencies=(
   "mingw-w64-ucrt-x86_64-graphviz"  # Optional, for docs
   "mingw-w64-ucrt-x86_64-MinHook"
   "mingw-w64-ucrt-x86_64-miniupnpc"
-  "mingw-w64-ucrt-x86_64-nodejs"
   "mingw-w64-ucrt-x86_64-nsis"
   "mingw-w64-ucrt-x86_64-onevpl"
   "mingw-w64-ucrt-x86_64-openssl"
@@ -112,6 +111,18 @@ dependencies=(
 )
 pacman -S "${dependencies[@]}"
 ```
+
+##### Install Node.js
+Install Node.js separately from [nodejs.org](https://nodejs.org/) (LTS or current) or via
+[nvm-windows](https://github.com/coreybutler/nvm-windows). Don't install MSYS2's
+`mingw-w64-ucrt-x86_64-nodejs` — it's compiled with the MSYS2 gcc-16 libstdc++ which has
+a `std::bad_weak_ptr` regression that crashes Node during process init (see
+[apache/arrow#49958](https://github.com/apache/arrow/issues/49958) for the upstream
+toolchain trail). The official MSVC-built Node.js isn't affected.
+
+Make sure `node.exe` is on `PATH` before running `cmake` — the `web-ui` CMake target
+invokes `npm install` via `find_program(NPM npm)`, so the official Node's `npm` must be
+visible to CMake.
 
 ### Clone
 Ensure [git](https://git-scm.com) is installed on your system, then clone the repository using the following command:


### PR DESCRIPTION
Hit this while building Apollo locally on Windows for a downstream patch.
`docs/building.md` currently tells Windows devs to `pacman -S mingw-w64-ucrt-x86_64-nodejs`,
which since the MSYS2 toolchain rolled to gcc 16.1 around 2026-04-30 has been crashing
the `web-ui` CMake target with `std::bad_weak_ptr` / `0xc0000409` — Node's own process
init blows up in the gcc-16 libstdc++ before `npm install` produces any output. Apache
Arrow tracked the same toolchain regression in [apache/arrow#49958][1] (CLANG64 / libc++
is unaffected, so it's specifically gcc-16 libstdc++). LizardByte/Sunshine sidesteps
it in [their Windows CI][2] by using `actions/setup-node` and omitting the MSYS2 nodejs
package; this PR brings the build doc into line — drop the MSYS2 nodejs from the deps
list, add a short note pointing at official Node.js / nvm-windows.

The C++ toolchain stays on `mingw-w64-ucrt-x86_64-toolchain` (gcc 16); the regression
only manifests inside Node's own internals, not Apollo's C++ code.

Verified the docs change in a downstream Apollo fork's CI matrix: ~60% failure rate
across rc4-rc11 with the MSYS2 nodejs in place, then 3-of-3 first-attempt passes
(rc13-15) after switching to official Node.

[1]: https://github.com/apache/arrow/issues/49958
[2]: https://github.com/LizardByte/Sunshine/blob/master/.github/workflows/ci-windows.yml
