### PR TITLE
Fix crash when paired-client booleans in sunshine_state.json are stored as strings

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -909,9 +909,9 @@ namespace confighttp {
       std::string uuid = input_tree.value("uuid", "");
       std::string name = input_tree.value("name", "");
       std::string display_mode = input_tree.value("display_mode", "");
-      bool enable_legacy_ordering = input_tree.value("enable_legacy_ordering", true);
-      bool allow_client_commands = input_tree.value("allow_client_commands", true);
-      bool always_use_virtual_display = input_tree.value("always_use_virtual_display", false);
+      bool enable_legacy_ordering = util::get_non_string_json_value<bool>(input_tree, "enable_legacy_ordering", true);
+      bool allow_client_commands = util::get_non_string_json_value<bool>(input_tree, "allow_client_commands", true);
+      bool always_use_virtual_display = util::get_non_string_json_value<bool>(input_tree, "always_use_virtual_display", false);
       auto do_cmds = nvhttp::extract_command_entries(input_tree, "do");
       auto undo_cmds = nvhttp::extract_command_entries(input_tree, "undo");
       auto perm = static_cast<crypto::PERM>(input_tree.value("perm", static_cast<uint32_t>(crypto::PERM::_no)) & static_cast<uint32_t>(crypto::PERM::_all));

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -346,9 +346,9 @@ namespace nvhttp {
         named_cert_p->uuid = el.value("uuid", "");
         named_cert_p->display_mode = el.value("display_mode", "");
         named_cert_p->perm = (PERM)(util::get_non_string_json_value<uint32_t>(el, "perm", (uint32_t)PERM::_all)) & PERM::_all;
-        named_cert_p->enable_legacy_ordering = el.value("enable_legacy_ordering", true);
-        named_cert_p->allow_client_commands = el.value("allow_client_commands", true);
-        named_cert_p->always_use_virtual_display = el.value("always_use_virtual_display", false);
+        named_cert_p->enable_legacy_ordering = util::get_non_string_json_value<bool>(el, "enable_legacy_ordering", true);
+        named_cert_p->allow_client_commands = util::get_non_string_json_value<bool>(el, "allow_client_commands", true);
+        named_cert_p->always_use_virtual_display = util::get_non_string_json_value<bool>(el, "always_use_virtual_display", false);
         // Load command entries for "do" and "undo" keys.
         named_cert_p->do_cmds = extract_command_entries(el, "do");
         named_cert_p->undo_cmds = extract_command_entries(el, "undo");


### PR DESCRIPTION
## Problem

On Windows 11, `Sunshine.exe` (Apollo v0.4.6) could crash on startup with an unhandled nlohmann::json exception:

`[json.exception.type_error.302] type must be boolean, but is string`

In the Windows Event Log this often showed up as a fault in `ucrtbase.dll` with exception code `0xc0000409` (abort after an unhandled exception / `std::terminate`).

In `sunshine_state.json`, under `root.named_devices`, the fields `allow_client_commands`, `always_use_virtual_display`, and `enable_legacy_ordering` were sometimes persisted as JSON strings (e.g. `"true"`) instead of JSON booleans. Reading them with `nlohmann::json::value(key, default_bool)` requires an actual boolean type, so parsing threw before initialization completed -sometimes leading to a service restart loop.

## Solution

Use the existing helper `util::get_non_string_json_value<bool>` for these three fields (same approach as for the `elevated` flag in client command entries), so both JSON booleans and string values like `"true"` are accepted.

- `src/nvhttp.cpp` - loading `file_state` (`sunshine_state.json`).
- `src/confighttp.cpp` - client update API, so the same string-encoded booleans in the request body do not trigger the same exception.
