### PR TITLE
[codex] Backport client certificate validation fix

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -33,8 +33,6 @@ namespace crypto {
       // Expired or not-yet-valid certificates are fine. Sometimes Moonlight is running on embedded devices
       // that don't have accurate clocks (or haven't yet synchronized by the time Moonlight first runs).
       // This behavior also matches what GeForce Experience does.
-      // TODO: Checking for X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY is a temporary workaround to get moonlight-embedded to work on the raspberry pi
-      case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
       case X509_V_ERR_CERT_NOT_YET_VALID:
       case X509_V_ERR_CERT_HAS_EXPIRED:
         return 1;


### PR DESCRIPTION
## Summary

Backports the upstream Sunshine client certificate validation fix for GHSA-ph75-mgxh-mv57 / CVE-2026-32253.

This removes the special-case success path for `X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY`, preventing an untrusted client certificate chain from being accepted as authorized.

## Provenance

Cherry-picked from LizardByte/Sunshine commit `888a6bb0cbdab97afb3df712f85f19c09dccd367` using `git cherry-pick -x`, preserving the original author metadata.

Upstream patched release: `v2026.516.143833`.

## Validation

- Confirmed `src/crypto.cpp` no longer contains `X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY` in the OpenSSL verify callback.
- Did not run a full Windows build locally.