### PR TITLE
fix: MSYS2 build compatibility on Windows

### DIFF
--- a/cmake/dependencies/Boost_Sunshine.cmake
+++ b/cmake/dependencies/Boost_Sunshine.cmake
@@ -30,7 +30,7 @@ endif()
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.30")
     cmake_policy(SET CMP0167 NEW)  # Get BoostConfig.cmake from upstream
 endif()
-find_package(Boost CONFIG ${BOOST_VERSION} EXACT COMPONENTS ${BOOST_COMPONENTS})
+find_package(Boost CONFIG COMPONENTS ${BOOST_COMPONENTS})
 if(NOT Boost_FOUND)
     message(STATUS "Boost v${BOOST_VERSION} package not found in the system. Falling back to FetchContent.")
     include(FetchContent)

--- a/cmake/targets/common.cmake
+++ b/cmake/targets/common.cmake
@@ -63,8 +63,8 @@ endif()
 add_custom_target(web-ui ALL
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         COMMENT "Installing NPM Dependencies and Building the Web UI"
-        COMMAND "$<$<BOOL:${WIN32}>:cmd;/C>" "${NPM}" install ${NPM_INSTALL_FLAGS}
-        COMMAND "${CMAKE_COMMAND}" -E env "SUNSHINE_BUILD_HOMEBREW=${NPM_BUILD_HOMEBREW}" "SUNSHINE_SOURCE_ASSETS_DIR=${NPM_SOURCE_ASSETS_DIR}" "SUNSHINE_ASSETS_DIR=${NPM_ASSETS_DIR}" "$<$<BOOL:${WIN32}>:cmd;/C>" "${NPM}" run build  # cmake-lint: disable=C0301
+        COMMAND "${CMAKE_COMMAND}" -E env "npm_config_scripts_prepend_node_path=true" "$<$<BOOL:${WIN32}>:cmd;/C>" "${NPM}" install ${NPM_INSTALL_FLAGS}
+        COMMAND "${CMAKE_COMMAND}" -E env "SUNSHINE_BUILD_HOMEBREW=${NPM_BUILD_HOMEBREW}" "SUNSHINE_SOURCE_ASSETS_DIR=${NPM_SOURCE_ASSETS_DIR}" "SUNSHINE_ASSETS_DIR=${NPM_ASSETS_DIR}" "npm_config_scripts_prepend_node_path=true" "$<$<BOOL:${WIN32}>:cmd;/C>" "${NPM}" run build  # cmake-lint: disable=C0301
         COMMAND_EXPAND_LISTS
         VERBATIM)
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -826,11 +826,7 @@ namespace video {
       },
       {
         // SDR-specific options
-        {"profile"s, [](const config_t &cfg) {
-           if (cfg.profile == 66) return "baseline"s;
-           if (cfg.profile == 77) return "main"s;
-           return "high"s;
-         }},
+        {"profile"s, "high"s},
       },
       {},  // HDR-specific options
       {},  // YUV444 SDR-specific options


### PR DESCRIPTION
## Summary

This PR fixes several build issues encountered when building Apollo on Windows using MSYS2 UCRT64.

### Changes

**cmake/dependencies/Boost_Sunshine.cmake**
Remove the  version constraint from . MSYS2 ships Boost 1.91.0 but the cmake script required exactly 1.89.0, causing the build to fall back to FetchContent unnecessarily. Removing  allows any compatible version to be used.

**src/video.cpp**
Fix compile error in AMD H.264 encoder options:  does not exist in  struct. Hardcode  profile as the constant value since the field is unavailable.

**cmake/targets/common.cmake**
Fix Web UI build failure on Windows: when CMake spawns Microsoft Windows [Version 10.0.26200.8457]
(c) Microsoft Corporation. All rights reserved.

C:\Users\re\Desktop\Workspace> subprocesses to run npm, the subprocesses cannot find  in PATH. Adding  instructs npm to automatically prepend the Node.js directory to PATH for all script invocations.

## Test Environment
- MSYS2 UCRT64
- Boost 1.91.0 (mingw-w64-ucrt-x86_64-boost)
- Node.js installed from nodejs.org (not MSYS2 package)