### PR TITLE
fix(video): wait for a configured output to appear before falling back

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1121,10 +1121,32 @@ namespace video {
 
     // If we had a name previously, let's try to find it in the new list
     if (!current_display_name.empty()) {
-      for (int x = 0; x < display_names.size(); ++x) {
-        if (display_names[x] == current_display_name) {
-          current_display_index = x;
-          return;
+      // When the user has explicitly pinned an output (output_name set), give it
+      // a brief grace period to appear before falling back. An on-demand virtual
+      // display (e.g. a headless connector brought up only for a stream) can
+      // still be settling in the compositor at the instant the encoder binds;
+      // without this we silently latch onto the wrong physical monitor for the
+      // whole session. Re-enumerate Apollo's own output list each attempt, since
+      // that — not the compositor's view — is the source of truth for capture.
+      const bool pinned = !output_name.empty() && current_display_name == output_name;
+      const int grace_attempts = pinned ? 10 : 1;  // pinned: up to ~10 * 200ms = 2s
+      for (int attempt = 0; attempt < grace_attempts; ++attempt) {
+        for (int x = 0; x < display_names.size(); ++x) {
+          if (display_names[x] == current_display_name) {
+            current_display_index = x;
+            return;
+          }
+        }
+
+        if (attempt + 1 < grace_attempts) {
+          if (attempt == 0) {
+            BOOST_LOG(info) << "Pinned output ["sv << current_display_name << "] not present yet; waiting for it to settle"sv;
+          }
+          std::this_thread::sleep_for(200ms);
+          auto refreshed = platf::display_names(dev_type);
+          if (!refreshed.empty()) {
+            display_names = std::move(refreshed);
+          }
         }
       }
 


### PR DESCRIPTION
## Problem

When `output_name` points at a display that is momentarily absent from the
enumeration at stream-bind time, `refresh_displays()` resets to the first
display and returns immediately. The capture then opens that fallback monitor,
caches its name in `proc::proc.display_name`, and never re-evaluates — so the
entire session streams the wrong output with no recovery.

This reliably bites on-demand virtual displays (a headless connector brought up
only for a stream), which can still be settling in the compositor at the instant
the encoder binds. It can also surface with displays returning from DPMS or
ordinary hotplug timing.

## Fix

When the missing display is the explicitly configured `output_name`, give it a
short grace window (~2s, 10 × 200ms) — re-enumerating `platf::display_names()`
each attempt — before falling back.

- Bounded: a genuinely-absent output still degrades to the previous fallback
  rather than hanging.
- Zero cost when the output is already present (matches on the first pass).
- Only the pinned output waits; auto-selected displays keep the original
  single-pass behaviour.
- Re-enumerates Apollo's own output list, which is the capture source of truth
  and can lag the compositor's view.
